### PR TITLE
Split token lexing into a separate compilation stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "exitcode"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +88,7 @@ name = "paty"
 version = "0.1.0"
 dependencies = [
  "chumsky",
+ "exitcode",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 chumsky = "0.7.0"
+exitcode = "1.1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub enum Expr {
 pub fn parser() -> impl Parser<Token, Expr, Error = Simple<Token>> + Clone {
     let op = |c| just(Token::Operator(c));
     let ident = filter_map(|span, tok| match tok {
-        Token::Identifier(ident) => Ok(ident.clone()),
+        Token::Identifier(ident) => Ok(ident),
         _ => Err(Simple::expected_input_found(span, Vec::new(), Some(tok))),
     })
     .labelled("identifier");
@@ -116,7 +116,7 @@ pub fn parser() -> impl Parser<Token, Expr, Error = Simple<Token>> + Clone {
             .foldl(|lhs, (op, rhs)| op(Box::new(lhs), Box::new(rhs)));
 
         // binary: "+", "-"
-        let sum = product
+        product
             .clone()
             .then(
                 op('+')
@@ -125,9 +125,7 @@ pub fn parser() -> impl Parser<Token, Expr, Error = Simple<Token>> + Clone {
                     .then(product)
                     .repeated(),
             )
-            .foldl(|lhs, (op, rhs)| op(Box::new(lhs), Box::new(rhs)));
-
-        sum
+            .foldl(|lhs, (op, rhs)| op(Box::new(lhs), Box::new(rhs)))
     });
 
     let decl = recursive(|decl| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,31 @@ fn main() {
     let filepath = env::args().nth(1).expect("filename");
     let src = fs::read_to_string(filepath).expect("Read source code");
 
-    match paty::parser().parse(src) {
-        Ok(ast) => match paty::eval(&ast) {
-            Ok(output) => println!("{}", output),
-            Err(err) => println!("Evaluation error: {}", err),
-        },
-        Err(err) => err.into_iter().for_each(|e| println!("Parse error: {}", e)),
-    }
+    let tokens = match paty::lexer().parse(src) {
+        Err(err) => {
+            err.into_iter()
+                .for_each(|e| eprintln!("Syntax error: {}", e));
+            std::process::exit(exitcode::DATAERR);
+        }
+        Ok(tokens) => tokens,
+    };
+    //println!("tokens = {:?}", tokens);
+
+    let ast = match paty::parser().parse(tokens) {
+        Err(err) => {
+            err.into_iter()
+                .for_each(|e| eprintln!("Parse error: {}", e));
+            std::process::exit(exitcode::DATAERR);
+        }
+        Ok(ast) => ast,
+    };
+    //println!("ast = {:?}", ast);
+
+    match paty::eval(&ast) {
+        Ok(output) => println!("{}", output),
+        Err(err) => {
+            eprintln!("Evaluation error: {}", err);
+            std::process::exit(exitcode::UNAVAILABLE);
+        }
+    };
 }


### PR DESCRIPTION
Split token lexing into a separate compilation stage to avoid the need for .padded() in the parser.