### PR TITLE
Add Tuple type

### DIFF
--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -1,7 +1,6 @@
 //! C code generator
-use crate::ty::Type;
-
 use super::ir::{Expr, ExprKind, Function, LiteralStr, Program, Stmt};
+use crate::ty::Type;
 
 #[derive(Debug)]
 pub struct Emitter {}
@@ -270,11 +269,16 @@ impl<'a, 'tcx> Emitter {
                 self.emit_expr(else_expr, code);
                 code.push(')');
             }
-            ExprKind::Int(n) => code.push_str(&format!("{}", *n)),
             ExprKind::Int64(n) => {
-                // Use standard macros for integer constant expression to expand
-                // a value to the type int_least_N.
-                code.push_str(&format!("INT64_C({})", *n))
+                match expr.ty() {
+                    Type::Int64 => {
+                        // Use standard macros for integer constant expression to expand
+                        // a value to the type int_least_N.
+                        code.push_str(&format!("INT64_C({})", *n))
+                    }
+                    Type::NativeInt => code.push_str(&format!("{}", *n)),
+                    _ => unreachable!("Unexpected integral type: {}", expr.ty()),
+                }
             }
             ExprKind::Bool(b) => {
                 // Use standard macros for boolean constant expression.

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -318,10 +318,10 @@ impl<'a, 'tcx> Emitter {
                     }
                 }
             }
-            ExprKind::Tuple(ty, values) => {
+            ExprKind::Tuple(values) => {
                 // Specify struct type explicitly.
                 code.push('(');
-                code.push_str(&c_type(ty));
+                code.push_str(&c_type(expr.ty()));
                 code.push(')');
 
                 // Initialize tuple struct with designated initializers.

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -293,19 +293,25 @@ impl<'a, 'tcx> Emitter {
             Value::LiteralStr(lits) => {
                 let mut it = lits.iter().peekable();
 
-                while let Some(lit) = it.next() {
+                // concatenate adjusting literal string
+                while let Some(lit) = it.peek() {
                     match lit {
-                        LiteralStr::Str(s) => {
+                        LiteralStr::Str(_) => {
                             code.push_str("u8\"");
-                            for c in s.escape_default() {
-                                code.push(c);
+                            while let Some(LiteralStr::Str(s)) = it.peek() {
+                                for c in s.escape_default() {
+                                    code.push(c);
+                                }
+                                it.next();
                             }
                             code.push('"');
                         }
                         LiteralStr::Macro(m) => {
                             code.push_str(m);
+                            it.next();
                         }
                     };
+
                     if it.peek().is_some() {
                         code.push(' ');
                     }

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -257,7 +257,7 @@ impl<'a, 'tcx> Emitter {
                 }
                 code.push(')');
             }
-            ExprKind::Select {
+            ExprKind::Cond {
                 condition,
                 then_expr,
                 else_expr,

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -1,7 +1,7 @@
 //! C code generator
 use crate::ty::Type;
 
-use super::ir::{Expr, ExprKind, Function, Program, Stmt, Value};
+use super::ir::{Expr, ExprKind, Function, LiteralStr, Program, Stmt, Value};
 
 #[derive(Debug)]
 pub struct Emitter {}
@@ -257,53 +257,17 @@ impl<'a, 'tcx> Emitter {
                 }
                 code.push(')');
             }
-            ExprKind::Printf { args } => {
-                code.push_str("printf(\"");
-                for (i, arg) in args.iter().enumerate() {
-                    match immediate(arg).ty() {
-                        Type::Int64 => {
-                            // Use standard conversion specifier macros for integer types.
-                            code.push_str("%\" PRId64 \"");
-                        }
-                        Type::Boolean => {
-                            // "true" / "false"
-                            code.push_str("%s");
-                        }
-                        Type::String => {
-                            code.push_str("%s");
-                        }
-                        Type::Tuple(_) => todo!(),
-                        Type::NativeInt => {
-                            code.push_str("%d");
-                        }
-                    }
-
-                    // separated by a space
-                    if i != (args.len() - 1) {
-                        code.push(' ');
-                    }
-                }
-                code.push_str("\\n\", ");
-
-                for (i, arg) in args.iter().enumerate() {
-                    match immediate(arg).ty() {
-                        Type::Int64 | Type::String | Type::NativeInt => {
-                            self.emit_expr(arg, code);
-                        }
-                        Type::Boolean => {
-                            // "true" / "false"
-                            code.push('(');
-                            self.emit_expr(arg, code);
-                            code.push_str(" ? \"true\" : \"false\"");
-                            code.push(')');
-                        }
-                        Type::Tuple(_) => todo!(),
-                    }
-
-                    if i != (args.len() - 1) {
-                        code.push_str(", ");
-                    }
-                }
+            ExprKind::Select {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                code.push('(');
+                self.emit_expr(condition, code);
+                code.push_str(" ? ");
+                self.emit_expr(then_expr, code);
+                code.push_str(" : ");
+                self.emit_expr(else_expr, code);
                 code.push(')');
             }
             ExprKind::Value(value) => self.emit_value(value, code),
@@ -326,12 +290,26 @@ impl<'a, 'tcx> Emitter {
                     code.push_str("false");
                 }
             }
-            Value::String(s) => {
-                code.push_str("u8\"");
-                for c in s.escape_default() {
-                    code.push(c);
+            Value::LiteralStr(lits) => {
+                let mut it = lits.iter().peekable();
+
+                while let Some(lit) = it.next() {
+                    match lit {
+                        LiteralStr::Str(s) => {
+                            code.push_str("u8\"");
+                            for c in s.escape_default() {
+                                code.push(c);
+                            }
+                            code.push('"');
+                        }
+                        LiteralStr::Macro(m) => {
+                            code.push_str(m);
+                        }
+                    };
+                    if it.peek().is_some() {
+                        code.push(' ');
+                    }
                 }
-                code.push('"');
             }
             Value::Tuple(ty, values) => {
                 // Specify struct type explicitly.
@@ -371,6 +349,7 @@ impl<'a, 'tcx> Emitter {
     }
 }
 
+/*
 fn immediate<'a, 'tcx>(expr: &'a Expr<'a, 'tcx>) -> &'a Expr<'a, 'tcx> {
     if let ExprKind::Value(Value::TmpVar(t)) = expr.kind() {
         if let Some(expr) = t.immediate.get() {
@@ -379,7 +358,7 @@ fn immediate<'a, 'tcx>(expr: &'a Expr<'a, 'tcx>) -> &'a Expr<'a, 'tcx> {
     }
     expr
 }
-
+*/
 fn c_type(ty: &Type) -> String {
     match ty {
         Type::Int64 => "int64_t".to_string(),

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -290,6 +290,13 @@ impl<'a, 'tcx> Emitter {
                     code.push_str("false");
                 }
             }
+            Value::Str(s) => {
+                code.push_str("u8\"");
+                for c in s.escape_default() {
+                    code.push(c);
+                }
+                code.push('"');
+            }
             Value::LiteralStr(lits) => {
                 let mut it = lits.iter().peekable();
 

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -31,6 +31,7 @@ impl<'a, 'tcx> Emitter {
         for ty in program.decl_types() {
             self.emit_decl_type(ty, &mut code);
             code.push('\n');
+            code.push('\n');
         }
 
         for fun in program.functions() {
@@ -332,7 +333,12 @@ impl<'a, 'tcx> Emitter {
                 }
                 code.push('"');
             }
-            Value::Tuple(_, values) => {
+            Value::Tuple(ty, values) => {
+                // Specify struct type explicitly.
+                code.push('(');
+                code.push_str(&c_type(ty));
+                code.push(')');
+
                 // Initialize tuple struct with designated initializers.
                 code.push('{');
 

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -28,7 +28,12 @@ impl<'a, 'tcx> Emitter {
         ]
         .join("\n");
 
-        for fun in &program.functions {
+        for ty in program.decl_types() {
+            self.emit_decl_type(ty, &mut code);
+            code.push('\n');
+        }
+
+        for fun in program.functions() {
             self.emit_function(fun, &mut code);
             code.push('\n');
         }
@@ -36,19 +41,37 @@ impl<'a, 'tcx> Emitter {
         code
     }
 
+    fn emit_decl_type(&mut self, ty: &Type<'tcx>, code: &mut String) {
+        match ty {
+            Type::Tuple(fs) => {
+                code.push_str(&c_type(ty));
+                code.push_str(" {\n");
+                for (i, fty) in fs.iter().enumerate() {
+                    code.push_str(&c_type(fty));
+                    code.push(' ');
+                    code.push_str(&format!("_{};\n", i));
+                }
+                code.push_str("};");
+            }
+            Type::Int64 | Type::Boolean | Type::String | Type::NativeInt => {
+                unreachable!("invalid type for declaration type: {}", ty);
+            }
+        }
+    }
+
     fn emit_function(&mut self, fun: &Function<'a, 'tcx>, code: &mut String) {
         if fun.is_entry_point {
             // 'main' must return 'int'
-            code.push_str(c_type(&Type::NativeInt));
+            code.push_str(&c_type(&Type::NativeInt));
         } else {
-            code.push_str(c_type(fun.retty));
+            code.push_str(&c_type(fun.retty));
         }
         code.push(' ');
 
         code.push_str(&fun.name);
         code.push('(');
         for (i, param) in fun.params.iter().enumerate() {
-            code.push_str(c_type(param.ty));
+            code.push_str(&c_type(param.ty));
             code.push(' ');
             code.push_str(&param.name);
 
@@ -71,7 +94,7 @@ impl<'a, 'tcx> Emitter {
             Stmt::TmpVarDef { var, init, pruned } => {
                 if !pruned.get() {
                     if var.used.get() > 0 {
-                        code.push_str(c_type(init.ty()));
+                        code.push_str(&c_type(init.ty()));
                         code.push(' ');
                         code.push_str(&format!("t{} = ", var.index));
                     }
@@ -80,7 +103,7 @@ impl<'a, 'tcx> Emitter {
                 }
             }
             Stmt::VarDef { name, init } => {
-                code.push_str(c_type(init.ty()));
+                code.push_str(&c_type(init.ty()));
                 code.push(' ');
                 code.push_str(name);
                 code.push_str(" = ");
@@ -103,7 +126,7 @@ impl<'a, 'tcx> Emitter {
             }
             Stmt::Cond { branches, var } => {
                 if var.used.get() > 0 {
-                    code.push_str(c_type(var.ty));
+                    code.push_str(&c_type(var.ty));
                     code.push(' ');
                     code.push_str(&format!("t{}", var.index));
                     code.push_str(";\n");
@@ -309,6 +332,27 @@ impl<'a, 'tcx> Emitter {
                 }
                 code.push('"');
             }
+            Value::Tuple(_, values) => {
+                // Initialize tuple struct with designated initializers.
+                code.push('{');
+
+                let mut peekable = values.iter().enumerate().peekable();
+
+                while let Some((i, value)) = peekable.next() {
+                    code.push_str(&format!("._{} = ", i));
+                    self.emit_expr(value, code);
+
+                    if peekable.peek().is_some() {
+                        code.push_str(", ");
+                    }
+                }
+
+                code.push('}');
+            }
+            Value::Field(operand, name) => {
+                self.emit_expr(operand, code);
+                code.push_str(&format!(".{}", name));
+            }
             Value::TmpVar(t) => {
                 if let Some(expr) = t.immediate.get() {
                     self.emit_expr(expr, code);
@@ -316,7 +360,7 @@ impl<'a, 'tcx> Emitter {
                     code.push_str(&format!("t{}", t.index));
                 }
             }
-            Value::Var(name, _) => code.push_str(name),
+            Value::Var(_, name) => code.push_str(name),
         }
     }
 }
@@ -330,12 +374,59 @@ fn immediate<'a, 'tcx>(expr: &'a Expr<'a, 'tcx>) -> &'a Expr<'a, 'tcx> {
     expr
 }
 
-fn c_type(ty: &Type) -> &'static str {
+fn c_type(ty: &Type) -> String {
     match ty {
-        Type::Int64 => "int64_t",
-        Type::Boolean => "bool",
-        Type::String => "const char *",
-        Type::NativeInt => "int",
-        Type::Tuple(_) => todo!(),
+        Type::Int64 => "int64_t".to_string(),
+        Type::Boolean => "bool".to_string(),
+        Type::String => "const char *".to_string(),
+        Type::NativeInt => "int".to_string(),
+        Type::Tuple(_) => {
+            let mut buffer = String::new();
+            encode_ty(ty, &mut buffer);
+            format!("struct _{}", buffer)
+        }
+    }
+}
+
+/// Encode type to C struct type name in universal way. "Universal" here means
+/// it is independent of runtime environment and machine architecture.
+///
+/// ## Integer types
+///
+/// ```ignore
+/// +-----+-------------------------+
+/// | "i" | digits (number of bits) |
+/// +-----+-------------------------+
+/// ```
+///
+/// ## Tuple type
+///
+/// ```ignore
+/// +-----+---------------------------+----------+
+/// | "T" | digits (number of fields) | (fields) |
+/// +-----+---------------------------+----------+
+/// ```
+///
+/// ## Other types
+///
+/// | Type           | Format |
+/// | -------------- | ------ |
+/// | `boolean`      | `"b"`  |
+/// | `string`       | `"s"`  |
+/// | `int` (C type) | `"ni"` |
+///
+fn encode_ty(ty: &Type, buffer: &mut String) {
+    match ty {
+        Type::Int64 => buffer.push_str("i64"),
+        Type::Boolean => buffer.push('b'),
+        Type::String => buffer.push('s'),
+        Type::NativeInt => buffer.push_str("ni"),
+        Type::Tuple(fs) => {
+            buffer.push('T');
+            buffer.push_str(&fs.len().to_string());
+            for fty in fs {
+                encode_ty(fty, buffer);
+            }
+        }
     }
 }

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -600,7 +600,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
 
                                 self.expr_arena.alloc(Expr::new(kind, self.tcx.boolean()))
                             }
-                            PatternKind::Or(_, _) => todo!(),
+                            PatternKind::Tuple(_) => todo!(),
                             PatternKind::Wildcard => self.expr_arena.alloc(self.bool(true)),
                         };
 

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -600,7 +600,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                                 self.expr_arena.alloc(Expr::new(kind, self.tcx.boolean()))
                             }
                             PatternKind::Or(_, _) => todo!(),
-                            PatternKind::Wildcard(_) => self.expr_arena.alloc(self.bool(true)),
+                            PatternKind::Wildcard => self.expr_arena.alloc(self.bool(true)),
                         };
 
                         let mut branch_stmts = vec![];

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -217,15 +217,15 @@ pub enum ExprKind<'a, 'tcx> {
     Ge(&'a Expr<'a, 'tcx>, &'a Expr<'a, 'tcx>),
     And(&'a Expr<'a, 'tcx>, &'a Expr<'a, 'tcx>),
     Or(&'a Expr<'a, 'tcx>, &'a Expr<'a, 'tcx>),
-    Call {
-        name: String,
-        args: Vec<&'a Expr<'a, 'tcx>>,
-    },
     // `condition ? yes_value : no_value`
-    Select {
+    Cond {
         condition: &'a Expr<'a, 'tcx>,
         then_expr: &'a Expr<'a, 'tcx>,
         else_expr: &'a Expr<'a, 'tcx>,
+    },
+    Call {
+        name: String,
+        args: Vec<&'a Expr<'a, 'tcx>>,
     },
     Value(Value<'a, 'tcx>),
 }
@@ -752,7 +752,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
             Type::Boolean => {
                 // "true" / "false"
                 let cond = self._build(expr, program, stmts);
-                let kind = ExprKind::Select {
+                let kind = ExprKind::Cond {
                     condition: self.inc_used(cond),
                     then_expr: self.const_string("true"),
                     else_expr: self.const_string("false"),
@@ -954,7 +954,7 @@ impl<'a, 'tcx> Optimizer {
                     self.optimize_expr(arg);
                 }
             }
-            ExprKind::Select {
+            ExprKind::Cond {
                 condition,
                 then_expr,
                 else_expr,

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -465,6 +465,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
 
                 self.push_expr(kind, expr, stmts)
             }
+            syntax::ExprKind::Elem(_, _) => todo!(),
             syntax::ExprKind::Call(name, args) => {
                 let kind = ExprKind::Call {
                     name: name.clone(),
@@ -684,11 +685,9 @@ impl<'a, 'tcx> Optimizer {
                 if var.used.get() == 1 {
                     // This temporary variable is used only once, so it could be
                     // replaced with the expression if it has no side-effect.
-                    //if let Expr::Value(_) = init {
                     var.immediate.set(Some(init));
                     pruned.set(true);
                     return;
-                    //}
                 }
                 self.optimize_expr(init);
             }

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -368,6 +368,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
 
                 self.push_expr(kind, expr, stmts)
             }
+            syntax::ExprKind::Tuple(_) => todo!(),
             syntax::ExprKind::Minus(a) => {
                 let a = self._build(a, program, stmts);
                 let kind = ExprKind::Minus(self.inc_used(a));

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -242,12 +242,13 @@ pub enum Value<'a, 'tcx> {
     Int(i32),
     Int64(i64),
     Bool(bool),
-    // Adjacent string literal (or macro) s can be combined into a single one.
-    LiteralStr(Vec<LiteralStr>),
+    Str(String),
     Tuple(&'tcx Type<'tcx>, Vec<&'a Expr<'a, 'tcx>>),
     Field(&'a Expr<'a, 'tcx>, String),
     TmpVar(&'a TmpVar<'a, 'tcx>),
     Var(&'tcx Type<'tcx>, String),
+    // Adjacent string literal (or macro) s can be combined into a single one.
+    LiteralStr(Vec<LiteralStr>),
 }
 
 impl<'a, 'tcx> Value<'a, 'tcx> {
@@ -402,7 +403,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
     }
 
     fn const_string(&self, value: &str) -> &'a Expr<'a, 'tcx> {
-        let kind = ExprKind::Value(Value::LiteralStr(vec![LiteralStr::Str(value.to_string())]));
+        let kind = ExprKind::Value(Value::Str(value.to_string()));
         let ty = self.tcx.string();
 
         self.expr_arena.alloc(Expr::new(kind, ty))

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -361,14 +361,6 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
         self.expr_arena.alloc(Expr::new(kind, expr.ty()))
     }
 
-    fn inc_used(&self, expr: &'a Expr<'a, 'tcx>) -> &'a Expr<'a, 'tcx> {
-        if let ExprKind::TmpVar(t) = expr.kind() {
-            t.used.set(t.used.get() + 1);
-        }
-
-        expr
-    }
-
     fn int64(&self, value: i64) -> &'a Expr<'a, 'tcx> {
         let kind = ExprKind::Int64(value);
         let ty = self.tcx.int64();
@@ -426,7 +418,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
 
                 for sub in sub_exprs {
                     let value = self._build(sub, program, stmts);
-                    values.push(self.inc_used(value));
+                    values.push(inc_used(value));
                 }
 
                 let kind = ExprKind::Tuple(tuple_ty, values);
@@ -434,91 +426,91 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
             }
             syntax::ExprKind::Minus(a) => {
                 let a = self._build(a, program, stmts);
-                let kind = ExprKind::Minus(self.inc_used(a));
+                let kind = ExprKind::Minus(inc_used(a));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::Add(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::Add(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::Add(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::Sub(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::Sub(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::Sub(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::Mul(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::Mul(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::Mul(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::Div(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::Div(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::Div(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::Eq(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::Eq(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::Eq(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::Ne(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::Ne(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::Ne(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::Lt(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::Lt(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::Lt(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::Gt(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::Gt(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::Gt(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::Le(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::Le(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::Le(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::Ge(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::Ge(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::Ge(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::And(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::And(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::And(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
             syntax::ExprKind::Or(a, b) => {
                 let a = self._build(a, program, stmts);
                 let b = self._build(b, program, stmts);
-                let kind = ExprKind::Or(self.inc_used(a), self.inc_used(b));
+                let kind = ExprKind::Or(inc_used(a), inc_used(b));
 
                 self.push_expr_kind(kind, expr.expect_ty(), stmts)
             }
@@ -529,7 +521,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
             syntax::ExprKind::TupleField(operand, index) => {
                 let operand = self._build(operand, program, stmts);
                 let kind = ExprKind::TupleField {
-                    operand: self.inc_used(operand),
+                    operand: inc_used(operand),
                     index: *index,
                 };
 
@@ -542,7 +534,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                         .iter()
                         .map(|a| {
                             let a = self._build(a, program, stmts);
-                            self.inc_used(a)
+                            inc_used(a)
                         })
                         .collect(),
                 };
@@ -587,7 +579,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                 let init = self._build(rhs, program, stmts);
                 let stmt = Stmt::VarDef {
                     name: name.clone(),
-                    init: self.inc_used(init),
+                    init: inc_used(init),
                 };
                 stmts.push(stmt);
                 self._build(then, program, stmts)
@@ -599,7 +591,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
 
                 let mut body_stmts = vec![];
                 let ret = self._build(syntax_fun.body(), program, &mut body_stmts);
-                body_stmts.push(Stmt::Ret(self.inc_used(ret)));
+                body_stmts.push(Stmt::Ret(inc_used(ret)));
 
                 let retty = syntax_fun.body().ty().unwrap();
 
@@ -644,7 +636,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                         let ret = self._build(arm.body(), program, &mut branch_stmts);
                         branch_stmts.push(Stmt::Phi {
                             var: t,
-                            value: self.inc_used(ret),
+                            value: inc_used(ret),
                             pruned: Cell::new(false),
                         });
 
@@ -660,7 +652,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                     let ret = self._build(else_body, program, &mut branch_stmts);
                     branch_stmts.push(Stmt::Phi {
                         var: t,
-                        value: self.inc_used(ret),
+                        value: inc_used(ret),
                         pruned: Cell::new(false),
                     });
 
@@ -726,29 +718,29 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                 // flatten values
                 for (i, sub_ty) in fs.iter().enumerate() {
                     let kind = ExprKind::TupleField {
-                        operand: self.inc_used(operand),
+                        operand: inc_used(operand),
                         index: i,
                     };
                     let ir_expr = self.push_expr_kind(kind, sub_ty, stmts);
 
-                    args.push(self.inc_used(ir_expr));
+                    args.push(inc_used(ir_expr));
                 }
             }
             Type::Boolean => {
                 // "true" / "false"
                 let cond = self._build(expr, program, stmts);
                 let kind = ExprKind::Cond {
-                    condition: self.inc_used(cond),
+                    condition: inc_used(cond),
                     then_expr: self.const_string("true"),
                     else_expr: self.const_string("false"),
                 };
                 let ir_expr = self.push_expr_kind(kind, self.tcx.string(), stmts);
 
-                args.push(self.inc_used(ir_expr));
+                args.push(inc_used(ir_expr));
             }
             Type::Int64 | Type::String | Type::NativeInt => {
                 let a = self._build(expr, program, stmts);
-                args.push(self.inc_used(a));
+                args.push(inc_used(a));
             }
         }
     }
@@ -761,15 +753,15 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
         match pat.kind() {
             PatternKind::Integer(n) => {
                 let value = self.int64(*n);
-                let eq = ExprKind::Eq(self.inc_used(t_head), value);
+                let eq = ExprKind::Eq(inc_used(t_head), value);
 
                 self.expr_arena.alloc(Expr::new(eq, self.tcx.boolean()))
             }
             PatternKind::Boolean(b) => {
                 if *b {
-                    self.inc_used(t_head)
+                    inc_used(t_head)
                 } else {
-                    let expr = ExprKind::Not(self.inc_used(t_head));
+                    let expr = ExprKind::Not(inc_used(t_head));
                     self.expr_arena.alloc(Expr::new(expr, self.tcx.boolean()))
                 }
             }
@@ -779,12 +771,12 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                 let value = self.const_string(s);
                 let kind = ExprKind::Call {
                     name: "strcmp".to_string(),
-                    args: vec![self.inc_used(t_head), value],
+                    args: vec![inc_used(t_head), value],
                 };
                 let strcmp = self.expr_arena.alloc(Expr::new(kind, self.tcx.int64()));
 
                 let zero = self.native_int(0);
-                let eq = ExprKind::Eq(self.inc_used(strcmp), zero);
+                let eq = ExprKind::Eq(inc_used(strcmp), zero);
 
                 self.expr_arena.alloc(Expr::new(eq, self.tcx.boolean()))
             }
@@ -792,11 +784,11 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                 let lo = self.int64(*lo);
                 let hi = self.int64(*hi);
 
-                let lhs = ExprKind::Ge(self.inc_used(t_head), lo);
+                let lhs = ExprKind::Ge(inc_used(t_head), lo);
 
                 let rhs = match end {
-                    syntax::RangeEnd::Included => ExprKind::Le(self.inc_used(t_head), hi),
-                    syntax::RangeEnd::Excluded => ExprKind::Lt(self.inc_used(t_head), hi),
+                    syntax::RangeEnd::Included => ExprKind::Le(inc_used(t_head), hi),
+                    syntax::RangeEnd::Excluded => ExprKind::Lt(inc_used(t_head), hi),
                 };
 
                 let kind = ExprKind::And(
@@ -812,7 +804,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                     self.bool(true)
                 } else {
                     let kind = ExprKind::TupleField {
-                        operand: self.inc_used(t_head),
+                        operand: inc_used(t_head),
                         index: 0,
                     };
                     let operand = self
@@ -823,7 +815,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
 
                     for (i, pat) in sub_pats.iter().enumerate().skip(1) {
                         let kind = ExprKind::TupleField {
-                            operand: self.inc_used(t_head),
+                            operand: inc_used(t_head),
                             index: i,
                         };
                         let operand = self.expr_arena.alloc(Expr::new(kind, pat.expect_ty()));
@@ -852,19 +844,6 @@ impl<'a, 'tcx> Optimizer {
         for fun in &mut program.functions {
             self.optimize_function(fun);
         }
-    }
-
-    fn decr_used_and_prunable(&self, expr: &'a Expr<'a, 'tcx>) -> bool {
-        if let ExprKind::TmpVar(t) = expr.kind() {
-            let u = t.used.get();
-            if u > 0 {
-                let u = u - 1;
-                t.used.set(u);
-
-                return u == 0 && t.immediate.get().is_none();
-            }
-        }
-        false
     }
 
     fn optimize_function(&mut self, fun: &Function<'a, 'tcx>) {
@@ -896,7 +875,7 @@ impl<'a, 'tcx> Optimizer {
                     // The result of cond expression is unused.
                     // So decrement the used count of a value because we increment it in
                     // Builder::build().
-                    if self.decr_used_and_prunable(value) {
+                    if dcr_used_and_prunable(value) {
                         pruned.set(true);
                         return;
                     }
@@ -965,4 +944,27 @@ impl<'a, 'tcx> Optimizer {
             | ExprKind::LiteralStr(_) => {}
         }
     }
+}
+
+// Temporary variable used (refed) counting
+
+fn inc_used<'a, 'tcx>(expr: &'a Expr<'a, 'tcx>) -> &'a Expr<'a, 'tcx> {
+    if let ExprKind::TmpVar(t) = expr.kind() {
+        t.used.set(t.used.get() + 1);
+    }
+
+    expr
+}
+
+fn dcr_used_and_prunable(expr: &Expr<'_, '_>) -> bool {
+    if let ExprKind::TmpVar(t) = expr.kind() {
+        let u = t.used.get();
+        if u > 0 {
+            let u = u - 1;
+            t.used.set(u);
+
+            return u == 0 && t.immediate.get().is_none();
+        }
+    }
+    false
 }

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -234,7 +234,7 @@ pub enum ExprKind<'a, 'tcx> {
     Int(i32),
     Bool(bool),
     Str(String),
-    Tuple(&'tcx Type<'tcx>, Vec<&'a Expr<'a, 'tcx>>),
+    Tuple(Vec<&'a Expr<'a, 'tcx>>),
     TupleField {
         operand: &'a Expr<'a, 'tcx>,
         index: usize,
@@ -411,7 +411,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
             syntax::ExprKind::Tuple(sub_exprs) => {
                 // Add tuple type to declaration types, because we have to
                 // declare tuple type as a struct type in C.
-                let tuple_ty = expr.ty().unwrap();
+                let tuple_ty = expr.expect_ty();
                 program.add_decl_type(tuple_ty);
 
                 let mut values = vec![];
@@ -421,8 +421,8 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                     values.push(inc_used(value));
                 }
 
-                let kind = ExprKind::Tuple(tuple_ty, values);
-                self.push_expr_kind(kind, expr.expect_ty(), stmts)
+                let kind = ExprKind::Tuple(values);
+                self.push_expr_kind(kind, tuple_ty, stmts)
             }
             syntax::ExprKind::Minus(a) => {
                 let a = self._build(a, program, stmts);
@@ -937,7 +937,7 @@ impl<'a, 'tcx> Optimizer {
             | ExprKind::Int(_)
             | ExprKind::Bool(_)
             | ExprKind::Str(_)
-            | ExprKind::Tuple(_, _)
+            | ExprKind::Tuple(_)
             | ExprKind::TupleField { .. }
             | ExprKind::TmpVar(_)
             | ExprKind::Var(_, _)

--- a/src/sem.rs
+++ b/src/sem.rs
@@ -219,7 +219,7 @@ fn analyze_expr<'pcx: 'tcx, 'tcx>(
             vars.insert(binding);
             analyze_expr(tcx, then, vars, functions, errors);
         }
-        syntax::ExprKind::Elem(operand, index) => {
+        syntax::ExprKind::TupleField(operand, index) => {
             analyze_expr(tcx, operand, vars, functions, errors);
 
             // index boundary check

--- a/src/sem.rs
+++ b/src/sem.rs
@@ -350,11 +350,15 @@ fn analyze_pattern<'pcx: 'tcx, 'tcx>(
         PatternKind::Range { .. } => {
             unify_pat_type(tcx.int64(), pat, errors);
         }
-        PatternKind::Or(pat1, pat2) => {
-            analyze_pattern(tcx, pat1, vars, functions, errors);
-            analyze_pattern(tcx, pat2, vars, functions, errors);
+        PatternKind::Tuple(patterns) => {
+            let mut sub_types = vec![];
 
-            todo!("or-pattern should be typed with an union type.");
+            for sub_pat in patterns {
+                analyze_pattern(tcx, sub_pat, vars, functions, errors);
+                sub_types.push(sub_pat.ty().unwrap());
+            }
+
+            unify_pat_type(tcx.tuple(&sub_types), pat, errors);
         }
         PatternKind::Wildcard => {}
     }

--- a/src/sem.rs
+++ b/src/sem.rs
@@ -153,6 +153,16 @@ fn analyze_expr<'pcx: 'tcx, 'tcx>(
         syntax::ExprKind::String(_) => {
             unify_expr_type(tcx.string(), expr, errors);
         }
+        syntax::ExprKind::Tuple(values) => {
+            let mut value_types = vec![];
+
+            for value in values {
+                analyze_expr(tcx, value, vars, functions, errors);
+                value_types.push(value.ty().unwrap());
+            }
+
+            unify_expr_type(tcx.tuple(&value_types), expr, errors);
+        }
         syntax::ExprKind::Minus(a) => {
             analyze_expr(tcx, a, vars, functions, errors);
 

--- a/src/sem/error.rs
+++ b/src/sem/error.rs
@@ -21,6 +21,8 @@ pub enum SemanticError<'tcx> {
         expected: &'tcx Type<'tcx>,
         actual: &'tcx Type<'tcx>,
     },
+    #[error("no field `{name}` on type `{ty}`")]
+    FieldNotFound { name: String, ty: &'tcx Type<'tcx> },
     // pattern match errors
     #[error("unreachable pattern: `{pattern}`")]
     UnreachablePattern { pattern: String },

--- a/src/sem/usefulness.rs
+++ b/src/sem/usefulness.rs
@@ -870,7 +870,7 @@ impl<'p, 'tcx> DeconstructedPat<'p, 'tcx> {
                 ctor = Constructor::Str(s.clone());
                 fields = Fields::empty();
             }
-            PatternKind::Or(_, _) => todo!(),
+            PatternKind::Tuple(_) => todo!(),
         }
 
         DeconstructedPat::new(ctor, fields, pat_ty)

--- a/src/syntax/token.rs
+++ b/src/syntax/token.rs
@@ -144,7 +144,7 @@ fn lexer() -> impl Parser<char, Vec<Token>, Error = Simple<char>> {
         .map(|s| TokenKind::Integer(format!("-{}", s)));
     let integer = pos_integer.or(neg_integer);
 
-    let operator1 = one_of("+-*/=(),<>:").map(TokenKind::Operator);
+    let operator1 = one_of("+-*/=(),<>:.").map(TokenKind::Operator);
     let operator2 = choice((
         just("..=").to(TokenKind::RangeIncluded),
         just("..<").to(TokenKind::RangeExcluded),

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -44,6 +44,15 @@ impl<'pcx, 'tcx> Expr<'pcx, 'tcx> {
         self.ty.get()
     }
 
+    pub fn expect_ty(&self) -> &'tcx Type<'tcx> {
+        self.ty().unwrap_or_else(|| {
+            panic!(
+                "Semantic analyzer can't assign type for expression {:?}",
+                self
+            );
+        })
+    }
+
     pub fn assign_ty(&self, ty: &'tcx Type<'tcx>) {
         self.ty.set(Some(ty))
     }

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -71,6 +71,7 @@ pub enum ExprKind<'pcx, 'tcx> {
     Boolean(bool),
     String(String),
     Var(String),
+    Tuple(Vec<&'pcx Expr<'pcx, 'tcx>>),
 
     // unary operators
     Minus(&'pcx Expr<'pcx, 'tcx>),

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -888,8 +888,8 @@ impl<'t, 'pcx, 'tcx> Parser<'pcx, 'tcx> {
     }
 
     fn peek_token(&self, it: &mut TokenIterator<'t>) -> Result<&'t Token, ParseError<'t>> {
-        //Ok(it.peek().ok_or(ParseError::PrematureEnd)?)
-        Ok(it.peek().unwrap())
+        Ok(it.peek().ok_or(ParseError::PrematureEnd)?)
+        //Ok(it.peek().unwrap())
     }
 
     fn expect_token(

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -236,6 +236,15 @@ impl<'pcx, 'tcx> Pattern<'pcx, 'tcx> {
         self.ty.get()
     }
 
+    pub fn expect_ty(&self) -> &'tcx Type<'tcx> {
+        self.ty().unwrap_or_else(|| {
+            panic!(
+                "Semantic analyzer can't assign type for pattern {}",
+                self.kind
+            );
+        })
+    }
+
     pub fn assign_ty(&self, ty: &'tcx Type<'tcx>) {
         self.ty.set(Some(ty))
     }

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -246,7 +246,7 @@ pub enum PatternKind<'pcx, 'tcx> {
     Boolean(bool),
     String(String),
     Range { lo: i64, hi: i64, end: RangeEnd },
-    Or(&'pcx Pattern<'pcx, 'tcx>, &'pcx Pattern<'pcx, 'tcx>),
+    Tuple(Vec<&'pcx Pattern<'pcx, 'tcx>>),
     Wildcard,
 }
 
@@ -271,7 +271,17 @@ impl fmt::Display for PatternKind<'_, '_> {
                     write!(f, "{}", hi)
                 }
             }
-            PatternKind::Or(_, _) => todo!(),
+            PatternKind::Tuple(patterns) => {
+                let mut it = patterns.iter().peekable();
+                write!(f, "(")?;
+                while let Some(sub_pat) = it.next() {
+                    write!(f, "{}", sub_pat.kind())?;
+                    if it.peek().is_some() {
+                        write!(f, ", ")?;
+                    }
+                }
+                write!(f, ")")
+            }
             PatternKind::Wildcard => write!(f, "_"),
         }
     }

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -100,7 +100,7 @@ pub enum ExprKind<'pcx, 'tcx> {
     Or(&'pcx Expr<'pcx, 'tcx>, &'pcx Expr<'pcx, 'tcx>),
 
     // tuple.0, tuple.1, ...
-    Elem(&'pcx Expr<'pcx, 'tcx>, usize),
+    TupleField(&'pcx Expr<'pcx, 'tcx>, usize),
     Call(String, Vec<&'pcx Expr<'pcx, 'tcx>>),
     Let {
         name: String,
@@ -769,7 +769,7 @@ impl<'t, 'pcx, 'tcx> Parser<'pcx, 'tcx> {
             if let TokenKind::Integer(n) = t.kind() {
                 it.next();
                 let index = n.parse().unwrap();
-                lhs = self.alloc_expr(ExprKind::Elem(lhs, index), token);
+                lhs = self.alloc_expr(ExprKind::TupleField(lhs, index), token);
             } else {
                 return Err(ParseError::UnexpectedToken {
                     expected: "index".to_string(),

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -90,6 +90,8 @@ pub enum ExprKind<'pcx, 'tcx> {
     And(&'pcx Expr<'pcx, 'tcx>, &'pcx Expr<'pcx, 'tcx>),
     Or(&'pcx Expr<'pcx, 'tcx>, &'pcx Expr<'pcx, 'tcx>),
 
+    // tuple.0, tuple.1, ...
+    Elem(&'pcx Expr<'pcx, 'tcx>, usize),
     Call(String, Vec<&'pcx Expr<'pcx, 'tcx>>),
     Let {
         name: String,

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -23,6 +23,11 @@ impl<'tcx> TypeContext<'tcx> {
         self.type_arena.alloc(Type::String)
     }
 
+    pub fn tuple(&self, value_types: &[&'tcx Type<'tcx>]) -> &'tcx Type<'tcx> {
+        self.type_arena
+            .alloc(Type::Tuple(value_types.iter().copied().collect()))
+    }
+
     pub fn native_int(&self) -> &'tcx Type<'tcx> {
         self.type_arena.alloc(Type::NativeInt)
     }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -56,7 +56,17 @@ impl fmt::Display for Type<'_> {
             Type::Boolean => write!(f, "boolean"),
             Type::String => write!(f, "string"),
             Type::NativeInt => write!(f, "int"),
-            Type::Tuple(_) => todo!(),
+            Type::Tuple(value_types) => {
+                let mut it = value_types.iter().peekable();
+                write!(f, "(")?;
+                while let Some(ty) = it.next() {
+                    write!(f, "{}", ty)?;
+                    if it.peek().is_some() {
+                        write!(f, ", ")?;
+                    }
+                }
+                write!(f, ")")
+            }
         }
     }
 }

--- a/test/error.sh
+++ b/test/error.sh
@@ -121,3 +121,7 @@ def foo(t: (int64, int64))
   end
 end
 foo((1, 2))"
+assert 'todo' "case (1,)
+when (1,)
+  puts(1)
+end"

--- a/test/error.sh
+++ b/test/error.sh
@@ -105,5 +105,9 @@ assert 'Semantic error: expected type `int64`, found `boolean`' "
 def foo(n: int64)
   n
 end
-foo(true)
-"
+foo(true)"
+assert 'Semantic error: expected type `(int64)`, found `int64`' "
+def foo(t: (int64,))
+  t
+end
+foo(100)"

--- a/test/error.sh
+++ b/test/error.sh
@@ -121,7 +121,8 @@ def foo(t: (int64, int64))
   end
 end
 foo((1, 2))"
-assert 'todo' "case (1,)
+assert 'Semantic error: non-exhaustive pattern: `(int64::MIN..=0)`
+Semantic error: non-exhaustive pattern: `(2..=int64::MAX)`' "case (1,)
 when (1,)
   puts(1)
 end"

--- a/test/error.sh
+++ b/test/error.sh
@@ -111,3 +111,13 @@ def foo(t: (int64,))
   t
 end
 foo(100)"
+assert 'todo' "
+def foo(t: (int64, int64))
+  case t
+  when (1, 2, 3)
+    puts(1)
+  else
+    puts(2)
+  end
+end
+foo((1, 2))"

--- a/test/error.sh
+++ b/test/error.sh
@@ -111,7 +111,7 @@ def foo(t: (int64,))
   t
 end
 foo(100)"
-assert 'todo' "
+assert 'Semantic error: expected type `(int64, int64)`, found `(int64, int64, int64)`' "
 def foo(t: (int64, int64))
   case t
   when (1, 2, 3)

--- a/test/error.sh
+++ b/test/error.sh
@@ -126,3 +126,8 @@ Semantic error: non-exhaustive pattern: `(2..=int64::MAX)`' "case (1,)
 when (1,)
   puts(1)
 end"
+# tuple
+assert 'Semantic error: no field `3` on type `(int64, int64, int64)`' "(1, 2, 3).3"
+assert 'Semantic error: no field `3` on type `(int64, int64, int64)`' "
+x = (1, 2, 3)
+x.3"

--- a/test/test.sh
+++ b/test/test.sh
@@ -159,8 +159,8 @@ def add_and_moreThan100(t: (int64, int64))
 end
 t1 = add_and_moreThan100((10, 20))
 t2 = add_and_moreThan100((90, 20))
-puts(t1.0, t1.1, t2.0, t2.1)
-"
+puts(t1.0, t1.1, t2.0, t2.1)"
+assert "(1, 2, 3)" "puts((1, 2, 3))"
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -153,6 +153,13 @@ assert '1 2 3 4' "
 assert "2022 1 22" "
 date = (2022, 1, 22)
 puts(date.0, date.1, date.2)"
+assert "30 false" "
+def add_and_moreThan100(t: (int64, int64))
+  (t.0 + t.1, t.0 + t.1 > 100)
+end
+t = add_and_moreThan100((10, 20))
+puts(t.0, t.1)
+"
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -148,8 +148,11 @@ assert '1 2 3 4' "
     fruit_to_num(\"Orange\"),
     fruit_to_num(\"Strawberry\"),
     fruit_to_num(\"Grape\")
-  )
-"
+  )"
+# tuple
+assert "2022 1 22" "
+date = (2022, 1, 22)
+puts(date.0, date.1, date.2)"
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -149,10 +149,6 @@ assert '1 2 3 4' "
     fruit_to_num(\"Strawberry\"),
     fruit_to_num(\"Grape\")
   )"
-# tuple
-assert "2022 1 22" "
-date = (2022, 1, 22)
-puts(date.0, date.1, date.2)"
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -149,6 +149,10 @@ assert '1 2 3 4' "
     fruit_to_num(\"Strawberry\"),
     fruit_to_num(\"Grape\")
   )"
+# tuple
+assert "2022 1 22" "
+date = (2022, 1, 22)
+puts(date.0, date.1, date.2)"
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -153,12 +153,13 @@ assert '1 2 3 4' "
 assert "2022 1 22" "
 date = (2022, 1, 22)
 puts(date.0, date.1, date.2)"
-assert "30 false" "
+assert "30 false 110 true" "
 def add_and_moreThan100(t: (int64, int64))
   (t.0 + t.1, t.0 + t.1 > 100)
 end
-t = add_and_moreThan100((10, 20))
-puts(t.0, t.1)
+t1 = add_and_moreThan100((10, 20))
+t2 = add_and_moreThan100((90, 20))
+puts(t1.0, t1.1, t2.0, t2.1)
 "
 # examples
 assert 13 "$(cat examples/foo.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -161,6 +161,24 @@ t1 = add_and_moreThan100((10, 20))
 t2 = add_and_moreThan100((90, 20))
 puts(t1.0, t1.1, t2.0, t2.1)"
 assert "(1, 2, 3)" "puts((1, 2, 3))"
+assert "1" "
+case (1, 2, 3)
+when (2, 3, 4)
+  puts(0)
+when (1, 2, 3)
+  puts(1)
+else
+  puts(2)
+end"
+assert "2" '
+case ("hello", true, 15)
+when ("hello", false, 15)
+  puts(1)
+when ("hello", true, 0..=15)
+  puts(2)
+else
+  puts(3)
+end'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"


### PR DESCRIPTION
You can construct a tuple in a number of ways:

- A pair of parentheses to denote an empty tuple: `()`
- A singleton tuple with trailing comma: `(a,)`
- Separating items with commas: `(a, b, c)`

