### PR TITLE
Add variable pattern

### DIFF
--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -56,6 +56,7 @@ impl<'a, 'tcx> Emitter {
             Type::Int64 | Type::Boolean | Type::String | Type::NativeInt => {
                 unreachable!("invalid type for declaration type: {}", ty);
             }
+            Type::Undetermined => unreachable!("untyped code"),
         }
     }
 
@@ -286,6 +287,7 @@ impl<'a, 'tcx> Emitter {
                                 Type::Tuple(_) => {
                                     unreachable!("compound value can't be printed: {:?}", value);
                                 }
+                                Type::Undetermined => unreachable!("untyped code"),
                             }
                         }
                     }
@@ -314,6 +316,7 @@ impl<'a, 'tcx> Emitter {
                             Type::Tuple(_) => {
                                 unreachable!("compound value can't be printed: {:?}", value);
                             }
+                            Type::Undetermined => unreachable!("untyped code"),
                         }
                     }
 
@@ -408,6 +411,7 @@ fn c_type(ty: &Type) -> String {
             encode_ty(ty, &mut buffer);
             format!("struct _{}", buffer)
         }
+        Type::Undetermined => unreachable!("untyped code"),
     }
 }
 
@@ -451,5 +455,6 @@ fn encode_ty(ty: &Type, buffer: &mut String) {
                 encode_ty(fty, buffer);
             }
         }
+        Type::Undetermined => unreachable!("untyped code"),
     }
 }

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -669,6 +669,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                 }
                 specs.push(FormatSpec::Str(")"));
             }
+            Type::Undetermined => unreachable!("untyped code"),
         }
     }
 

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -595,11 +595,12 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                 let mut branches = arms
                     .iter()
                     .map(|arm| {
-                        // Build an immediate value from the pattern
-                        let condition = self._build_pattern(t_head, arm.pattern());
-
+                        // Build an condition and variable declarations from the pattern
                         let mut branch_stmts = vec![];
+                        let condition =
+                            self._build_pattern(t_head, arm.pattern(), &mut branch_stmts);
                         let ret = self._build(arm.body(), program, &mut branch_stmts);
+
                         branch_stmts.push(Stmt::Phi {
                             var: t,
                             value: inc_used(ret),
@@ -673,21 +674,22 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
 
     fn _build_pattern(
         &mut self,
-        t_head: &'a Expr<'a, 'tcx>,
+        t_expr: &'a Expr<'a, 'tcx>,
         pat: &'pcx syntax::Pattern<'pcx, 'tcx>,
+        stmts: &mut Vec<Stmt<'a, 'tcx>>,
     ) -> &'a Expr<'a, 'tcx> {
         match pat.kind() {
             PatternKind::Integer(n) => {
                 let value = self.int64(*n);
-                let eq = ExprKind::Eq(inc_used(t_head), value);
+                let eq = ExprKind::Eq(inc_used(t_expr), value);
 
                 self.expr_arena.alloc(Expr::new(eq, self.tcx.boolean()))
             }
             PatternKind::Boolean(b) => {
                 if *b {
-                    inc_used(t_head)
+                    inc_used(t_expr)
                 } else {
-                    let expr = ExprKind::Not(inc_used(t_head));
+                    let expr = ExprKind::Not(inc_used(t_expr));
                     self.expr_arena.alloc(Expr::new(expr, self.tcx.boolean()))
                 }
             }
@@ -697,7 +699,7 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                 let value = self.const_string(s);
                 let kind = ExprKind::Call {
                     name: "strcmp".to_string(),
-                    args: vec![inc_used(t_head), value],
+                    args: vec![inc_used(t_expr), value],
                 };
                 let strcmp = self.expr_arena.alloc(Expr::new(kind, self.tcx.int64()));
 
@@ -710,11 +712,11 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                 let lo = self.int64(*lo);
                 let hi = self.int64(*hi);
 
-                let lhs = ExprKind::Ge(inc_used(t_head), lo);
+                let lhs = ExprKind::Ge(inc_used(t_expr), lo);
 
                 let rhs = match end {
-                    syntax::RangeEnd::Included => ExprKind::Le(inc_used(t_head), hi),
-                    syntax::RangeEnd::Excluded => ExprKind::Lt(inc_used(t_head), hi),
+                    syntax::RangeEnd::Included => ExprKind::Le(inc_used(t_expr), hi),
+                    syntax::RangeEnd::Excluded => ExprKind::Lt(inc_used(t_expr), hi),
                 };
 
                 let kind = ExprKind::And(
@@ -730,28 +732,37 @@ impl<'a, 'pcx: 'tcx, 'tcx> Builder<'a, 'tcx> {
                     self.bool(true)
                 } else {
                     let kind = ExprKind::TupleField {
-                        operand: inc_used(t_head),
+                        operand: inc_used(t_expr),
                         index: 0,
                     };
                     let operand = self
                         .expr_arena
                         .alloc(Expr::new(kind, sub_pats[0].expect_ty()));
 
-                    let mut condition = self._build_pattern(operand, sub_pats[0]);
+                    let mut condition = self._build_pattern(operand, sub_pats[0], stmts);
 
                     for (i, pat) in sub_pats.iter().enumerate().skip(1) {
                         let kind = ExprKind::TupleField {
-                            operand: inc_used(t_head),
+                            operand: inc_used(t_expr),
                             index: i,
                         };
                         let operand = self.expr_arena.alloc(Expr::new(kind, pat.expect_ty()));
 
-                        let kind = ExprKind::And(condition, self._build_pattern(operand, pat));
+                        let kind =
+                            ExprKind::And(condition, self._build_pattern(operand, pat, stmts));
                         condition = self.expr_arena.alloc(Expr::new(kind, self.tcx.boolean()))
                     }
 
                     condition
                 }
+            }
+            PatternKind::Variable(name) => {
+                stmts.push(Stmt::VarDef {
+                    name: name.clone(),
+                    init: inc_used(t_expr),
+                });
+
+                self.bool(true)
             }
             PatternKind::Wildcard => self.bool(true),
         }

--- a/src/sem.rs
+++ b/src/sem.rs
@@ -394,10 +394,16 @@ fn analyze_pattern<'pcx: 'tcx, 'tcx>(
             unify_pat_type(tcx.tuple(sub_types), pat, errors);
         }
         PatternKind::Variable(name) => {
+            if vars.get(name).is_some() {
+                errors.push(SemanticError::AlreadyBoundInPattern { name: name.clone() });
+                return;
+            }
+
             // We need the type of pattern.
             unify_pat_type(expected_ty, pat, errors);
 
             let binding = Binding::new(name, pat.expect_ty());
+
             vars.insert(binding);
         }
         PatternKind::Wildcard => {}

--- a/src/sem/error.rs
+++ b/src/sem/error.rs
@@ -30,4 +30,6 @@ pub enum SemanticError<'tcx> {
     UnreachableElseClause,
     #[error("non-exhaustive pattern: `{pattern}`")]
     NonExhaustivePattern { pattern: String },
+    #[error("identifier `{name}` is bound more than once in the same pattern")]
+    AlreadyBoundInPattern { name: String },
 }

--- a/src/sem/usefulness.rs
+++ b/src/sem/usefulness.rs
@@ -335,9 +335,9 @@ impl<'tcx> SplitWildcard {
                 ));
                 vec![ctor]
             }
-            // This type is one for which we cannot list constructors, like `str` or `f64`.
-            Type::String => vec![Constructor::NonExhaustive],
             Type::Tuple(_) => vec![Constructor::Single],
+            // This type is one for which we cannot list constructors, like `str` or `f64`.
+            Type::String | Type::Undetermined => vec![Constructor::NonExhaustive],
             Type::NativeInt => unreachable!("Native C types are not supported."),
         };
 

--- a/src/sem/usefulness.rs
+++ b/src/sem/usefulness.rs
@@ -872,7 +872,7 @@ impl<'p, 'tcx> DeconstructedPat<'p, 'tcx> {
         let ctor;
         let fields;
         match pat.kind() {
-            PatternKind::Wildcard => {
+            PatternKind::Variable(_) | PatternKind::Wildcard => {
                 ctor = Constructor::Wildcard;
                 fields = Fields::empty();
             }

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -335,7 +335,16 @@ impl<'t, 'pcx, 'tcx> Parser<'pcx, 'tcx> {
 
     pub fn parse(&self, tokens: &'t [Token]) -> ParseResult<'t, 'pcx, 'tcx> {
         let mut it = tokens.iter().peekable();
-        self.decl(&mut it)
+        let expr = self.decl(&mut it)?;
+
+        if let Some(token) = it.peek() {
+            Err(ParseError::UnexpectedToken {
+                expected: "(EOF)".to_string(),
+                actual: token,
+            })
+        } else {
+            Ok(expr)
+        }
     }
 
     // --- Parser

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -47,7 +47,7 @@ impl<'pcx, 'tcx> Expr<'pcx, 'tcx> {
     pub fn expect_ty(&self) -> &'tcx Type<'tcx> {
         self.ty().unwrap_or_else(|| {
             panic!(
-                "Semantic analyzer can't assign type for expression {:?}",
+                "Semantic analyzer couldn't assign type for expression {:?}",
                 self
             );
         })
@@ -239,7 +239,7 @@ impl<'pcx, 'tcx> Pattern<'pcx, 'tcx> {
     pub fn expect_ty(&self) -> &'tcx Type<'tcx> {
         self.ty().unwrap_or_else(|| {
             panic!(
-                "Semantic analyzer can't assign type for pattern {}",
+                "Semantic analyzer couldn't assign type for pattern {}",
                 self.kind
             );
         })
@@ -267,6 +267,7 @@ pub enum PatternKind<'pcx, 'tcx> {
     String(String),
     Range { lo: i64, hi: i64, end: RangeEnd },
     Tuple(Vec<&'pcx Pattern<'pcx, 'tcx>>),
+    Variable(String),
     Wildcard,
 }
 
@@ -302,6 +303,7 @@ impl fmt::Display for PatternKind<'_, '_> {
                 }
                 write!(f, ")")
             }
+            PatternKind::Variable(name) => write!(f, "{}", name),
             PatternKind::Wildcard => write!(f, "_"),
         }
     }
@@ -596,12 +598,12 @@ impl<'t, 'pcx, 'tcx> Parser<'pcx, 'tcx> {
             TokenKind::Identifier(name) => {
                 it.next();
 
-                if name == "_" {
-                    let kind = PatternKind::Wildcard;
-                    self.alloc_pat(kind, token)
+                let kind = if name == "_" {
+                    PatternKind::Wildcard
                 } else {
-                    return Err(ParseError::NotParsed);
-                }
+                    PatternKind::Variable(name.clone())
+                };
+                self.alloc_pat(kind, token)
             }
             _ => {
                 return Err(ParseError::NotParsed);

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -593,6 +593,16 @@ impl<'t, 'pcx, 'tcx> Parser<'pcx, 'tcx> {
                     unreachable!("invalid tuple or group");
                 }
             }
+            TokenKind::Identifier(name) => {
+                it.next();
+
+                if name == "_" {
+                    let kind = PatternKind::Wildcard;
+                    self.alloc_pat(kind, token)
+                } else {
+                    return Err(ParseError::NotParsed);
+                }
+            }
             _ => {
                 return Err(ParseError::NotParsed);
             }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -23,6 +23,10 @@ impl<'tcx> TypeContext<'tcx> {
         self.type_arena.alloc(Type::String)
     }
 
+    pub fn undetermined(&self) -> &'tcx Type<'tcx> {
+        self.type_arena.alloc(Type::Undetermined)
+    }
+
     pub fn tuple(&self, value_types: &[&'tcx Type<'tcx>]) -> &'tcx Type<'tcx> {
         self.type_arena
             .alloc(Type::Tuple(value_types.iter().copied().collect()))
@@ -31,10 +35,10 @@ impl<'tcx> TypeContext<'tcx> {
     /// Returns a tuple type whose element type is unknown but has N elements.
     pub fn tuple_n(&self, n: usize) -> &'tcx Type<'tcx> {
         let mut value_types = vec![];
+        let undetermined = &*self.type_arena.alloc(Type::Undetermined);
 
         for _ in 0..n {
-            // TODO: add unknown type
-            value_types.push(self.int64());
+            value_types.push(undetermined);
         }
 
         self.tuple(&value_types)
@@ -56,6 +60,9 @@ pub enum Type<'tcx> {
     /// tuple
     Tuple(Vec<&'tcx Type<'tcx>>),
 
+    /// Type is not specified and should be inferred in the later phase.
+    Undetermined,
+
     // C types for internal uses
     /// int
     NativeInt,
@@ -68,6 +75,7 @@ impl fmt::Display for Type<'_> {
             Type::Boolean => write!(f, "boolean"),
             Type::String => write!(f, "string"),
             Type::NativeInt => write!(f, "int"),
+            Type::Undetermined => write!(f, "_"),
             Type::Tuple(value_types) => {
                 let mut it = value_types.iter().peekable();
                 write!(f, "(")?;

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -28,6 +28,18 @@ impl<'tcx> TypeContext<'tcx> {
             .alloc(Type::Tuple(value_types.iter().copied().collect()))
     }
 
+    /// Returns a tuple type whose element type is unknown but has N elements.
+    pub fn tuple_n(&self, n: usize) -> &'tcx Type<'tcx> {
+        let mut value_types = vec![];
+
+        for _ in 0..n {
+            // TODO: add unknown type
+            value_types.push(self.int64());
+        }
+
+        self.tuple(&value_types)
+    }
+
     pub fn native_int(&self) -> &'tcx Type<'tcx> {
         self.type_arena.alloc(Type::NativeInt)
     }

--- a/test/error.sh
+++ b/test/error.sh
@@ -100,6 +100,12 @@ assert 'Semantic error: non-exhaustive pattern: `_`' "
   when \"B\"
     puts(2)
   end"
+# binding variables
+assert 'identifier `x` is bound more than once in the same pattern' "
+case (10, 20, 30)
+when (x, x, z)
+  puts(x + x + z)
+end"
 # type check
 assert 'Semantic error: expected type `int64`, found `boolean`' "
 def foo(n: int64)

--- a/test/test.sh
+++ b/test/test.sh
@@ -107,9 +107,13 @@ assert 152 "
     end
   end
   puts(pt(1) + pt(5) + pt(10) + pt(20))"
+assert '1' "
+case 102030
+when _
+  puts(1)
+end"
 assert '102030' "
-n = 102030
-case n
+case 102030
 when x
   puts(x)
 end"

--- a/test/test.sh
+++ b/test/test.sh
@@ -107,6 +107,12 @@ assert 152 "
     end
   end
   puts(pt(1) + pt(5) + pt(10) + pt(20))"
+assert '102030' "
+n = 102030
+case n
+when x
+  puts(x)
+end"
 # boolean
 assert 'true' "
   n = 5

--- a/test/test.sh
+++ b/test/test.sh
@@ -117,6 +117,18 @@ case 102030
 when x
   puts(x)
 end"
+assert '15' "
+case (true, 15)
+when (false, _)
+  puts(0)
+when (true, x)
+  puts(x)
+end"
+assert '60' "
+case (10, 20, 30)
+when (x, y, z)
+  puts(x + y + z)
+end"
 # boolean
 assert 'true' "
   n = 5


### PR DESCRIPTION
You can capture matched values with variable patterns.

```ruby
t = (1, 2, 3)
case t
when x
  puts(x)  # (1, 2, 3)
end

case t
when (x, _, z)
  puts(x, z)  # 1 3
end
```