### PR TITLE
Eliminate unconditional condition

### DIFF
--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -174,6 +174,8 @@ impl<'a, 'tcx> Emitter {
                 }
 
                 // Construct "if-else" statement from each branches.
+                // If a branch has only one branch and it has no condition,
+                // this loop finally generate a block statement.
                 for (i, branch) in branches.iter().enumerate() {
                     if i > 0 {
                         code.push_str("else ");
@@ -185,7 +187,7 @@ impl<'a, 'tcx> Emitter {
                         code.push_str(") ");
                     }
 
-                    // body
+                    // body (block)
                     code.push_str("{\n");
                     for stmt in &branch.body {
                         self.emit_stmt(stmt, code);

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -71,7 +71,10 @@ impl<'a, 'tcx> Emitter {
                 }
                 code.push_str("};");
             }
-            Type::Int64 | Type::Boolean | Type::String | Type::NativeInt => {}
+            Type::Int64 | Type::Boolean | Type::String | Type::NativeInt => {
+                // no emit
+                return;
+            }
             Type::Undetermined => unreachable!("untyped code"),
         };
 


### PR DESCRIPTION
Until now, when compiled this kind of code, wildcards and variable patterns were converted to `if (true)`, which generated useless conditionals. It was too ugly, so I decided to remove these kindo of conditions for wildcards and variable patterns.

```ruby
case (10, 20, 30)
when (x, y, z)
  puts(x + y + z)
end
```

to C code:

```c
if (((true && true) && true))
{
  int64_t x = t4._0;
  int64_t y = t4._1;
  int64_t z = t4._2;
  printf("%" PRId64 "\n", ((x + y) + z));
}
```

After this PR:

```c
{
  int64_t x = t4._0;
  int64_t y = t4._1;
  int64_t z = t4._2;
  printf("%" PRId64 "\n", ((x + y) + z));
}
```

