### PR TITLE
Anonymous structures and spread operators/patterns

### DIFF
--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -185,7 +185,7 @@ impl<'a, 'tcx> Emitter {
                     }
 
                     // Emit init statement if needed
-                    if var.used.get() > 0 || self.has_side_effect(init) {
+                    if var.used.get() > 0 || init.has_side_effect() {
                         self.emit_expr(init, code);
                         code.push_str(";\n");
                     }
@@ -537,37 +537,6 @@ impl<'a, 'tcx> Emitter {
                 }
             }
             ExprKind::Var(var) => code.push_str(var.name()),
-        }
-    }
-
-    fn has_side_effect(&self, expr: &Expr) -> bool {
-        match expr.kind() {
-            ExprKind::Minus(a) | ExprKind::Not(a) => self.has_side_effect(a),
-            ExprKind::Add(a, b)
-            | ExprKind::Sub(a, b)
-            | ExprKind::Mul(a, b)
-            | ExprKind::Div(a, b)
-            | ExprKind::Eq(a, b)
-            | ExprKind::Ne(a, b)
-            | ExprKind::Lt(a, b)
-            | ExprKind::Le(a, b)
-            | ExprKind::Gt(a, b)
-            | ExprKind::Ge(a, b)
-            | ExprKind::And(a, b)
-            | ExprKind::Or(a, b) => self.has_side_effect(a) || self.has_side_effect(b),
-            ExprKind::Call { .. } => true,
-            ExprKind::Printf(_) => true,
-            ExprKind::Tuple(fs) => fs.iter().any(|sub_expr| self.has_side_effect(sub_expr)),
-            ExprKind::StructValue(fs) => fs
-                .iter()
-                .any(|(_, sub_expr)| self.has_side_effect(sub_expr)),
-            ExprKind::Int64(_)
-            | ExprKind::Bool(_)
-            | ExprKind::Str(_)
-            | ExprKind::IndexAccess { .. }
-            | ExprKind::FieldAccess { .. }
-            | ExprKind::TmpVar(_)
-            | ExprKind::Var(_) => false,
         }
     }
 }

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -551,7 +551,7 @@ fn immediate<'a, 'tcx>(expr: &'a Expr<'a, 'tcx>) -> &'a Expr<'a, 'tcx> {
 }
 
 fn tmp_var(t: &TmpVar) -> String {
-    format!("t{}", t.index)
+    format!("_t{}", t.index)
 }
 
 fn c_type(ty: &Type) -> String {

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -618,22 +618,22 @@ fn c_type(ty: &Type) -> String {
 /// ## Tuple type
 ///
 /// ```ignore
-/// +-----+---------------------------+-----+---------------+
-/// | "T" | digits (number of fields) | "_" | (field types) |
-/// +-----+---------------------------+-----+---------------+
+/// +-----+---------------------------+---------------+
+/// | "T" | digits (number of fields) | (field types) |
+/// +-----+---------------------------+---------------+
 /// ```
 ///
 /// ## Anonymous struct type
 ///
 /// ```ignore
-/// +-----+---------------------------+-----+----------------+
-/// | "S" | digits (number of fields) | "_" | (named fields) |
-/// +-----+---------------------------+-----+----------------+
+/// +-----+---------------------------+----------------+
+/// | "S" | digits (number of fields) | (named fields) |
+/// +-----+---------------------------+----------------+
 ///
 /// named field:
-/// +-------------------------------------------+------+------+
-/// | digits (The length of the following name) | name | type |
-/// +-------------------------------------------+------+------+
+/// +------+-------------------------------------------+------+
+/// | type | digits (The length of the following name) | name |
+/// +------+-------------------------------------------+------+
 ///
 /// ```
 ///
@@ -662,7 +662,6 @@ fn encode_ty(ty: &Type, buffer: &mut String) {
         Type::Tuple(fs) => {
             buffer.push('T');
             buffer.push_str(&fs.len().to_string());
-            buffer.push('_');
             for fty in fs {
                 encode_ty(fty, buffer);
             }
@@ -670,10 +669,10 @@ fn encode_ty(ty: &Type, buffer: &mut String) {
         Type::AnonStruct(struct_ty) => {
             buffer.push('S');
             buffer.push_str(&struct_ty.fields().len().to_string());
-            buffer.push('_');
             for f in struct_ty.fields() {
-                buffer.push_str(&f.name().len().to_string());
                 encode_ty(f.ty(), buffer);
+                buffer.push_str(&f.name().len().to_string());
+                buffer.push_str(f.name());
             }
         }
         Type::Struct(struct_ty) => {

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -80,11 +80,11 @@ impl<'a, 'tcx> Emitter {
             Type::Struct(struct_ty) => {
                 code.push_str(&c_type(ty));
                 code.push_str(" {\n");
-                for (name, fty) in struct_ty.fields() {
-                    if !fty.is_zero_sized() {
-                        code.push_str(&c_type(fty));
+                for f in struct_ty.fields() {
+                    if !f.ty().is_zero_sized() {
+                        code.push_str(&c_type(f.ty()));
                         code.push(' ');
-                        code.push_str(&format!("{};\n", name));
+                        code.push_str(&format!("{};\n", f.name()));
                     }
                 }
                 code.push_str("};\n\n");

--- a/src/gen/c.rs
+++ b/src/gen/c.rs
@@ -498,7 +498,7 @@ impl<'a, 'tcx> Emitter {
 
                 code.push('}');
             }
-            ExprKind::StructValue(_, fs) => {
+            ExprKind::StructValue(fs) => {
                 // Specify struct type explicitly.
                 code.push('(');
                 code.push_str(&c_type(expr.ty()));
@@ -561,7 +561,7 @@ impl<'a, 'tcx> Emitter {
             ExprKind::Call { .. } => true,
             ExprKind::Printf(_) => true,
             ExprKind::Tuple(fs) => fs.iter().any(|sub_expr| self.has_side_effect(sub_expr)),
-            ExprKind::StructValue(_, fs) => fs
+            ExprKind::StructValue(fs) => fs
                 .iter()
                 .any(|(_, sub_expr)| self.has_side_effect(sub_expr)),
             ExprKind::Int64(_)

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -615,6 +615,11 @@ impl<'a, 'nd: 'tcx, 'tcx> Builder<'a, 'tcx> {
                 self.push_expr_kind(kind, tuple_ty, stmts)
             }
             syntax::ExprKind::AnonStruct(struct_value) => {
+                // Add anonymous struct type to declaration types, because we have to
+                // declare a type as a struct type in C.
+                // However, the Zero-sized struct should not have a definition.
+                program.add_decl_type(expr.expect_ty());
+
                 let mut fields = vec![];
 
                 for f in struct_value.fields() {

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -498,6 +498,9 @@ impl<'a, 'nd: 'tcx, 'tcx> Builder<'a, 'tcx> {
                     let pat = p.pattern();
                     let ty = pat.expect_ty();
 
+                    // To emit anonymous struct type
+                    program.add_decl_type(ty);
+
                     // Assign parameter names to be able to referenced later.
                     let param = match pat.kind() {
                         PatternKind::Var(name) => Parameter::Var(Var::new(name, ty)),

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -610,9 +610,14 @@ impl<'a, 'nd: 'tcx, 'tcx> Builder<'a, 'tcx> {
             syntax::ExprKind::Struct(struct_value) => {
                 let mut fields = vec![];
 
-                for field in struct_value.fields() {
-                    let value = self._build_expr(field.value(), program, stmts);
-                    fields.push((field.name().to_string(), inc_used(value)));
+                for f in struct_value.fields() {
+                    match f {
+                        syntax::ValueFieldOrSpread::ValueField(field) => {
+                            let value = self._build_expr(field.value(), program, stmts);
+                            fields.push((field.name().to_string(), inc_used(value)));
+                        }
+                        syntax::ValueFieldOrSpread::Spread(_) => todo!(),
+                    }
                 }
 
                 let kind = ExprKind::StructValue(struct_value.name().to_string(), fields);

--- a/src/gen/ir.rs
+++ b/src/gen/ir.rs
@@ -28,8 +28,8 @@ impl<'a, 'tcx> Program<'a, 'tcx> {
                 }
             }
             Type::Struct(struct_ty) => {
-                for (_, fty) in struct_ty.fields() {
-                    self.add_decl_type(fty);
+                for f in struct_ty.fields() {
+                    self.add_decl_type(f.ty());
                 }
             }
             Type::Int64 | Type::Boolean | Type::String | Type::NativeInt => {
@@ -939,7 +939,7 @@ impl<'a, 'nd: 'tcx, 'tcx> Builder<'a, 'tcx> {
                 specs.push(FormatSpec::Str(")"));
             }
             Type::Struct(struct_ty) => {
-                let mut it = struct_ty.fields().peekable();
+                let mut it = struct_ty.fields().iter().peekable();
                 let empty = it.peek().is_none();
 
                 specs.push(FormatSpec::Value(self.const_string(struct_ty.name())));
@@ -948,16 +948,16 @@ impl<'a, 'nd: 'tcx, 'tcx> Builder<'a, 'tcx> {
                     specs.push(FormatSpec::Str(" "));
                 }
 
-                while let Some((name, fty)) = it.next() {
-                    specs.push(FormatSpec::Value(self.const_string(name)));
+                while let Some(f) = it.next() {
+                    specs.push(FormatSpec::Value(self.const_string(f.name())));
                     specs.push(FormatSpec::Str(": "));
 
                     let kind = ExprKind::FieldAccess {
                         operand: inc_used(arg),
-                        name: name.to_string(),
+                        name: f.name().to_string(),
                     };
 
-                    let ir_expr = self.push_expr_kind(kind, fty, stmts);
+                    let ir_expr = self.push_expr_kind(kind, f.ty(), stmts);
                     self._printf_format(ir_expr, program, stmts, specs);
 
                     if it.peek().is_some() {

--- a/src/sem.rs
+++ b/src/sem.rs
@@ -209,6 +209,11 @@ fn resolve_type<'tcx>(
                 resolve_type(tcx, f.ty(), named_types, errors);
             }
         }
+        Type::AnonStruct(struct_ty) => {
+            for f in struct_ty.fields() {
+                resolve_type(tcx, f.ty(), named_types, errors);
+            }
+        }
         Type::Named(named_ty) => {
             if named_ty.ty().is_none() {
                 if let Some(ty) = named_types.get(named_ty.name()) {

--- a/src/sem.rs
+++ b/src/sem.rs
@@ -526,7 +526,14 @@ fn analyze_expr<'nd: 'tcx, 'tcx>(
 
             // index boundary check
             let ty = operand.expect_ty();
+
             if let Type::Struct(struct_ty) = ty {
+                if let Some(f) = struct_ty.get_field(name) {
+                    // apply type
+                    unify_expr_type(f.ty(), expr, errors);
+                    return;
+                }
+            } else if let Type::AnonStruct(struct_ty) = ty {
                 if let Some(f) = struct_ty.get_field(name) {
                     // apply type
                     unify_expr_type(f.ty(), expr, errors);

--- a/src/sem/error.rs
+++ b/src/sem/error.rs
@@ -1,5 +1,27 @@
+use std::fmt;
+
 use crate::ty::{FunctionSignature, Type};
 use thiserror::Error;
+
+#[derive(Debug)]
+pub struct FormatSymbols {
+    pub names: Vec<String>,
+}
+
+impl fmt::Display for FormatSymbols {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut it = self.names.iter().peekable();
+
+        while let Some(name) = it.next() {
+            write!(f, "`{}`", name)?;
+            if it.peek().is_some() {
+                write!(f, ", ")?;
+            }
+        }
+
+        Ok(())
+    }
+}
 
 #[derive(Error, Debug)]
 pub enum SemanticError<'tcx> {
@@ -9,8 +31,11 @@ pub enum SemanticError<'tcx> {
     UndefinedFunction { name: String },
     #[error("cannot find named type `{name}` in scope")]
     UndefinedNamedType { name: String },
-    #[error("cannot find named field `{name}` in struct `{struct_name}`")]
-    UndefinedStructField { name: String, struct_name: String },
+    #[error("cannot find named field `{name}` in struct `{struct_ty}`")]
+    UndefinedStructField {
+        name: String,
+        struct_ty: &'tcx Type<'tcx>,
+    },
     #[error("named field `{name}` is defined more than once in struct `{struct_name}`")]
     DuplicateStructField { name: String, struct_name: String },
     #[error("function `{signature}` is defined more than once in the same scope")]
@@ -36,6 +61,11 @@ pub enum SemanticError<'tcx> {
     #[error("no field `{name}` on type `{ty}`")]
     FieldNotFound { name: String, ty: &'tcx Type<'tcx> },
     // pattern match errors
+    #[error("uncovered fields `{names}` in struct pattern `{struct_ty}`")]
+    UncoveredStructFields {
+        names: FormatSymbols,
+        struct_ty: &'tcx Type<'tcx>,
+    },
     #[error("unreachable pattern: `{pattern}`")]
     UnreachablePattern { pattern: String },
     #[error("unreachable `else` clause")]
@@ -44,4 +74,6 @@ pub enum SemanticError<'tcx> {
     NonExhaustivePattern { pattern: String },
     #[error("identifier `{name}` is bound more than once in the same pattern")]
     AlreadyBoundInPattern { name: String },
+    #[error("spread pattern can appear only once: `{pattern}`")]
+    DuplicateSpreadPattern { pattern: String },
 }

--- a/src/sem/error.rs
+++ b/src/sem/error.rs
@@ -31,13 +31,16 @@ pub enum SemanticError<'tcx> {
     UndefinedFunction { name: String },
     #[error("cannot find named type `{name}` in scope")]
     UndefinedNamedType { name: String },
-    #[error("cannot find named field `{name}` in struct `{struct_ty}`")]
+    #[error("cannot find named field `{name}` in `{struct_ty}`")]
     UndefinedStructField {
         name: String,
         struct_ty: &'tcx Type<'tcx>,
     },
-    #[error("named field `{name}` is defined more than once in struct `{struct_name}`")]
-    DuplicateStructField { name: String, struct_name: String },
+    #[error("named field `{name}` is defined more than once in `{struct_ty}`")]
+    DuplicateStructField {
+        name: String,
+        struct_ty: &'tcx Type<'tcx>,
+    },
     #[error("function `{signature}` is defined more than once in the same scope")]
     DuplicateFunction { signature: FunctionSignature<'tcx> },
     #[error("named type `{name}` is bound more than once in the same scope")]
@@ -76,4 +79,8 @@ pub enum SemanticError<'tcx> {
     AlreadyBoundInPattern { name: String },
     #[error("spread pattern can appear only once: `{pattern}`")]
     DuplicateSpreadPattern { pattern: String },
+    #[error("empty spread expression is no-op")]
+    EmptySpreadExpression,
+    #[error("value of `{ty}` cannot be spread")]
+    InvalidSpreadOperand { ty: &'tcx Type<'tcx> },
 }

--- a/src/sem/error.rs
+++ b/src/sem/error.rs
@@ -61,7 +61,7 @@ pub enum SemanticError<'tcx> {
     #[error("no field `{name}` on type `{ty}`")]
     FieldNotFound { name: String, ty: &'tcx Type<'tcx> },
     // pattern match errors
-    #[error("uncovered fields `{names}` in struct pattern `{struct_ty}`")]
+    #[error("uncovered fields {names} in struct pattern `{struct_ty}`")]
     UncoveredStructFields {
         names: FormatSymbols,
         struct_ty: &'tcx Type<'tcx>,

--- a/src/sem/usefulness.rs
+++ b/src/sem/usefulness.rs
@@ -4,8 +4,7 @@
 use super::error::SemanticError;
 use crate::syntax::token::RangeEnd;
 use crate::syntax::{
-    AnonStructPattern, CaseArm, Pattern, PatternField, PatternFieldOrSpread, PatternKind,
-    StructPattern,
+    CaseArm, Pattern, PatternField, PatternFieldOrSpread, PatternKind, StructPattern,
 };
 use crate::ty::Type;
 use std::{
@@ -914,32 +913,6 @@ impl<'p, 'tcx> DeconstructedPat<'p, 'tcx> {
 
                 fields = Fields::from_iter(cx, pats);
             }
-            PatternKind::AnonStruct(struct_pat) => {
-                ctor = Constructor::Single;
-
-                // Convert struct fields to deconstruct patterns.
-                // We must follow the order of fields in the type.
-                let struct_ty = if let Type::Struct(struct_ty) = pat_ty {
-                    struct_ty
-                } else {
-                    unreachable!("Pattern type {} must be struct type.", pat_ty);
-                };
-
-                let mut sub_pats = vec![];
-
-                for f in struct_ty.fields() {
-                    let sub_pat = if let Some(pat_field) = struct_pat.get_field(f.name()) {
-                        DeconstructedPat::from_pat(cx, pat_field.pattern())
-                    } else {
-                        // omitted fields are handled by wildcard
-                        DeconstructedPat::wildcard(f.ty())
-                    };
-
-                    sub_pats.push(sub_pat);
-                }
-
-                fields = Fields::from_iter(cx, sub_pats);
-            }
             PatternKind::Struct(struct_pat) => {
                 ctor = Constructor::Single;
 
@@ -992,9 +965,9 @@ impl<'p, 'tcx> DeconstructedPat<'p, 'tcx> {
                         .collect();
 
                     if let Some(name) = struct_ty.name() {
-                        PatternKind::Struct(StructPattern::new(name.to_string(), pat_fields))
+                        PatternKind::Struct(StructPattern::new(Some(name.to_string()), pat_fields))
                     } else {
-                        PatternKind::AnonStruct(AnonStructPattern::new(pat_fields))
+                        PatternKind::Struct(StructPattern::new(None, pat_fields))
                     }
                 }
                 _ => unreachable!("unexpected ctor for type {:?} {:?}", self.ctor, self.ty),

--- a/src/sem/usefulness.rs
+++ b/src/sem/usefulness.rs
@@ -964,7 +964,10 @@ impl<'p, 'tcx> DeconstructedPat<'p, 'tcx> {
                         .map(PatternFieldOrSpread::PatternField)
                         .collect();
 
-                    PatternKind::Struct(StructPattern::new(struct_ty.name(), pat_fields))
+                    PatternKind::Struct(StructPattern::new(
+                        struct_ty.name().to_string(),
+                        pat_fields,
+                    ))
                 }
                 _ => unreachable!("unexpected ctor for type {:?} {:?}", self.ctor, self.ty),
             },

--- a/src/sem/usefulness.rs
+++ b/src/sem/usefulness.rs
@@ -337,7 +337,7 @@ impl<'tcx> SplitWildcard {
                 ));
                 vec![ctor]
             }
-            Type::Tuple(_) | Type::Struct(_) => vec![Constructor::Single],
+            Type::Tuple(_) | Type::Struct(_) | Type::AnonStruct(_) => vec![Constructor::Single],
             // This type is one for which we cannot list constructors, like `str` or `f64`.
             Type::String | Type::Named(_) | Type::Undetermined => vec![Constructor::NonExhaustive],
             Type::NativeInt => unreachable!("Native C types are not supported."),

--- a/src/sem/usefulness.rs
+++ b/src/sem/usefulness.rs
@@ -809,6 +809,9 @@ impl<'p, 'tcx> Fields<'p, 'tcx> {
         match constructor {
             Constructor::Single => match ty {
                 Type::Tuple(fs) => Fields::wildcards_from_tys(cx, fs.iter().copied()),
+                Type::AnonStruct(struct_ty) => {
+                    Fields::wildcards_from_tys(cx, struct_ty.fields().iter().map(|f| f.ty()))
+                }
                 Type::Struct(struct_ty) => {
                     Fields::wildcards_from_tys(cx, struct_ty.fields().iter().map(|f| f.ty()))
                 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3,6 +3,6 @@ pub mod tree;
 
 pub use token::{tokenize, RangeEnd, Token, TokenKind};
 pub use tree::{
-    Declaration, DeclarationKind, Expr, ExprKind, Function, Parser, Pattern, PatternKind, Stmt,
-    StmtKind, StructDeclaration, TopLevel,
+    CaseArm, Declaration, DeclarationKind, Expr, ExprKind, Function, Parser, Pattern, PatternField,
+    PatternFieldOrSpread, PatternKind, Stmt, StmtKind, StructDeclaration, StructPattern, TopLevel,
 };

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3,7 +3,7 @@ pub mod tree;
 
 pub use token::{tokenize, RangeEnd, Token, TokenKind};
 pub use tree::{
-    CaseArm, Declaration, DeclarationKind, Expr, ExprKind, Function, Parser, Pattern, PatternField,
-    PatternFieldOrSpread, PatternKind, Stmt, StmtKind, StructDeclaration, StructPattern, TopLevel,
-    ValueFieldOrSpread,
+    AnonStructPattern, CaseArm, Declaration, DeclarationKind, Expr, ExprKind, Function, Parser,
+    Pattern, PatternField, PatternFieldOrSpread, PatternKind, Stmt, StmtKind, StructDeclaration,
+    StructPattern, TopLevel, ValueFieldOrSpread,
 };

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3,7 +3,7 @@ pub mod tree;
 
 pub use token::{tokenize, RangeEnd, Token, TokenKind};
 pub use tree::{
-    AnonStructPattern, CaseArm, Declaration, DeclarationKind, Expr, ExprKind, Function, Parser,
-    Pattern, PatternField, PatternFieldOrSpread, PatternKind, Stmt, StmtKind, StructDeclaration,
-    StructPattern, TopLevel, ValueFieldOrSpread,
+    CaseArm, Declaration, DeclarationKind, Expr, ExprKind, Function, Parser, Pattern, PatternField,
+    PatternFieldOrSpread, PatternKind, Stmt, StmtKind, StructDeclaration, StructPattern, TopLevel,
+    ValueFieldOrSpread,
 };

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -5,4 +5,5 @@ pub use token::{tokenize, RangeEnd, Token, TokenKind};
 pub use tree::{
     CaseArm, Declaration, DeclarationKind, Expr, ExprKind, Function, Parser, Pattern, PatternField,
     PatternFieldOrSpread, PatternKind, Stmt, StmtKind, StructDeclaration, StructPattern, TopLevel,
+    ValueFieldOrSpread,
 };

--- a/src/syntax/token.rs
+++ b/src/syntax/token.rs
@@ -80,6 +80,7 @@ pub enum TokenKind {
     // Operators
     RangeIncluded, // RangeEnd::Included
     RangeExcluded, // RangeEnd::Excluded
+    Spread,        // "..."
     Eq,
     Ne,
     Le,
@@ -111,6 +112,7 @@ impl fmt::Display for TokenKind {
             Self::String(s) => write!(f, "\"{}\"", s.escape_default().collect::<String>()),
             Self::RangeIncluded => write!(f, "{}", RangeEnd::Included),
             Self::RangeExcluded => write!(f, "{}", RangeEnd::Excluded),
+            Self::Spread => write!(f, "..."),
             Self::Operator(c) => write!(f, "{}", c),
             Self::Eq => write!(f, "=="),
             Self::Ne => write!(f, "!="),
@@ -150,6 +152,7 @@ fn lexer() -> impl Parser<char, Vec<Token>, Error = Simple<char>> {
     let operator2 = choice((
         just("..=").to(TokenKind::RangeIncluded),
         just("..<").to(TokenKind::RangeExcluded),
+        just("...").to(TokenKind::Spread),
         just("==").to(TokenKind::Eq),
         just("!=").to(TokenKind::Ne),
         just("<=").to(TokenKind::Le),

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -1828,6 +1828,11 @@ impl<'t, 'nd, 'tcx> Parser<'nd, 'tcx> {
                 it.next();
                 ExprKind::Boolean(false)
             }
+            TokenKind::Operator('{') => {
+                let fields = self.parse_elements(it, ('{', '}'), Self::value_field)?;
+                let struct_value = AnonStructValue::new(fields);
+                ExprKind::AnonStruct(struct_value)
+            }
             TokenKind::Operator('(') => {
                 // tuple or grouping values.
                 // - `()` -> empty tuple

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -1485,6 +1485,12 @@ impl<'t, 'nd, 'tcx> Parser<'nd, 'tcx> {
                     unreachable!("invalid tuple or group");
                 }
             }
+            TokenKind::Operator('{') => {
+                let fields = self.parse_elements(it, ('{', '}'), Self::pattern_field)?;
+                let struct_value = AnonStructPattern::new(fields);
+                let kind = PatternKind::AnonStruct(struct_value);
+                self.alloc_pat(kind, token)
+            }
             TokenKind::Identifier(name) => {
                 it.next();
                 if self.match_token(it, TokenKind::Operator('{')) {

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -585,6 +585,11 @@ impl<'nd, 'tcx> SpreadExpr<'nd, 'tcx> {
     pub fn operand(&self) -> Option<&'nd Expr<'nd, 'tcx>> {
         self.operand
     }
+
+    pub fn expect_operand(&self) -> &'nd Expr<'nd, 'tcx> {
+        self.operand
+            .unwrap_or_else(|| panic!("spread operator without an operand is illegal."))
+    }
 }
 
 impl fmt::Display for SpreadExpr<'_, '_> {

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -886,6 +886,17 @@ impl<'tcx> SpreadPattern<'tcx> {
         })
     }
 
+    pub fn expect_struct_ty(&self) -> &StructTy<'tcx> {
+        if let Type::Struct(struct_ty) = self.expect_ty() {
+            struct_ty
+        } else {
+            unreachable!(
+                "spread pattern type must be anonymous struct: {}",
+                self.expect_ty()
+            );
+        }
+    }
+
     pub fn assign_ty(&self, ty: &'tcx Type<'tcx>) {
         self.ty.set(Some(ty))
     }

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -1193,7 +1193,7 @@ impl<'t, 'nd, 'tcx> Parser<'nd, 'tcx> {
             .iter()
             .map(|f| TypedField::new(f.name().to_string(), f.ty()))
             .collect();
-        let struct_ty = StructTy::new(name.to_string(), fs);
+        let struct_ty = StructTy::new_named(name.to_string(), fs);
         let ty = self.tcx.type_arena.alloc(Type::Struct(struct_ty));
 
         let r#struct = StructDeclaration { name, fields, ty };

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -1,5 +1,5 @@
 use crate::syntax::{RangeEnd, Token, TokenKind};
-use crate::ty::{FunctionSignature, NamedTy, StructTy, StructTyField, Type, TypeContext};
+use crate::ty::{FunctionSignature, NamedTy, StructTy, Type, TypeContext, TypedField};
 use std::cell::Cell;
 use std::fmt;
 use std::iter::Peekable;
@@ -1070,11 +1070,11 @@ impl<'t, 'nd, 'tcx> Parser<'nd, 'tcx> {
         let fields = self.parse_elements(it, ('{', '}'), Self::struct_field_definition)?;
 
         // Build struct type
-        let fs: Vec<StructTyField> = fields
+        let fs: Vec<TypedField<'_>> = fields
             .iter()
-            .map(|f| (f.name().to_string(), f.ty()))
+            .map(|f| TypedField::new(f.name().to_string(), f.ty()))
             .collect();
-        let struct_ty = StructTy::new(&name, fs);
+        let struct_ty = StructTy::new(name.to_string(), fs);
         let ty = self.tcx.type_arena.alloc(Type::Struct(struct_ty));
 
         let r#struct = StructDeclaration { name, fields, ty };

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -33,6 +33,15 @@ impl<'tcx> TypeContext<'tcx> {
             .alloc(Type::Tuple(value_types.iter().copied().collect()))
     }
 
+    pub fn empty_anon_struct_ty(&self) -> &'tcx Type<'tcx> {
+        self.anon_struct_ty(vec![])
+    }
+
+    pub fn anon_struct_ty(&self, fields: Vec<TypedField<'tcx>>) -> &'tcx Type<'tcx> {
+        let struct_ty = AnonStructTy::new(fields);
+        self.type_arena.alloc(Type::AnonStruct(struct_ty))
+    }
+
     pub fn struct_ty(&self, name: String, fields: Vec<TypedField<'tcx>>) -> &'tcx Type<'tcx> {
         let struct_ty = StructTy::new(name, fields);
         self.type_arena.alloc(Type::Struct(struct_ty))

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -80,6 +80,8 @@ pub enum Type<'tcx> {
     Tuple(Vec<&'tcx Type<'tcx>>),
     /// struct
     Struct(StructTy<'tcx>),
+    /// anonymous struct
+    AnonStruct(AnonStructTy<'tcx>),
 
     /// Type is specified by name and should be resolved in the later phase
     Named(NamedTy<'tcx>),
@@ -111,6 +113,9 @@ impl<'tcx> Type<'tcx> {
             Type::Int64 | Type::Boolean | Type::String | Type::NativeInt => false,
             Type::Tuple(fs) => fs.is_empty() || fs.iter().all(|x| x.is_zero_sized()),
             Type::Struct(struct_ty) => struct_ty.fields().iter().all(|f| f.ty().is_zero_sized()),
+            Type::AnonStruct(struct_ty) => {
+                struct_ty.fields().iter().all(|f| f.ty().is_zero_sized())
+            }
             Type::Named(named_ty) => {
                 if let Some(ty) = named_ty.ty() {
                     ty.is_zero_sized()
@@ -155,6 +160,7 @@ impl Hash for Type<'_> {
         match self {
             Type::Tuple(fs) => fs.hash(state),
             Type::Struct(struct_ty) => struct_ty.hash(state),
+            Type::AnonStruct(struct_ty) => struct_ty.hash(state),
             Type::Named(named_ty) => {
                 if let Some(ty) = named_ty.ty() {
                     ty.hash(state)
@@ -190,6 +196,7 @@ impl fmt::Display for Type<'_> {
                 write!(f, ")")
             }
             Type::Struct(struct_ty) => struct_ty.fmt(f),
+            Type::AnonStruct(struct_ty) => struct_ty.fmt(f),
         }
     }
 }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -142,6 +142,7 @@ impl PartialEq for Type<'_> {
         match (self, other) {
             (Self::Tuple(l0), Self::Tuple(r0)) => l0 == r0,
             (Self::Struct(l0), Self::Struct(r0)) => l0 == r0,
+            (Self::AnonStruct(l0), Self::AnonStruct(r0)) => l0 == r0,
             (Self::Named(named_ty1), Self::Named(named_ty2)) => {
                 named_ty1.name() == named_ty2.name() || named_ty1.ty() == named_ty2.ty()
             }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -263,6 +263,37 @@ impl fmt::Display for StructTyBody<'_> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AnonStructTy<'tcx> {
+    body: StructTyBody<'tcx>,
+}
+
+impl<'tcx> AnonStructTy<'tcx> {
+    pub fn new(fields: Vec<TypedField<'tcx>>) -> Self {
+        // The order of fields must be sorted so that anonymous struct can be
+        // matched by structural.
+        let mut fs = fields;
+        fs.sort_by(|a, b| a.name().cmp(b.name()));
+
+        let body = StructTyBody::new(fs);
+        Self { body }
+    }
+
+    pub fn fields(&self) -> &[TypedField<'tcx>] {
+        self.body.fields()
+    }
+
+    pub fn get_field(&self, name: &str) -> Option<&TypedField<'tcx>> {
+        self.body.get_field(name)
+    }
+}
+
+impl fmt::Display for AnonStructTy<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.body)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StructTy<'tcx> {
     name: String,
     body: StructTyBody<'tcx>,

--- a/test/error.sh
+++ b/test/error.sh
@@ -234,3 +234,9 @@ assert 'Semantic error: no field `b` on type `struct A { a: int64 }`' "
 struct A { a: int64 }
 a = A { a: 100 }
 a.b"
+# anonymous struct
+assert 'expected type `{ a: int64, b: int64 }`, found `int64`' '
+def foo(opts: { a: int64, b: int64 })
+  opts.a + opts.b
+end
+foo(100)'

--- a/test/error.sh
+++ b/test/error.sh
@@ -87,7 +87,7 @@ assert 'Semantic error: unreachable pattern: `T { value: 0 }`' "
   struct T { value: int64 }
   t = T { value: 123 }
   case t
-  when T {}
+  when T { ... }
     puts(t)
   when T { value: 0 }
     puts(t)
@@ -150,6 +150,15 @@ assert 'Semantic error: non-exhaustive pattern: `T { a: false, b: false }`' "
     puts(2)
   when T { a: false, b: true }
     puts(3)
+  end"
+# uncovered fields
+assert 'Semantic error: uncovered fields `value` in struct pattern `struct T { value: int64 }`' "
+  struct T { value: int64 }
+  case T { value: 123 }
+  when T {}
+    puts(0)
+  else
+    puts(1)
   end"
 # binding variables
 assert 'identifier `x` is bound more than once in the same pattern' "

--- a/test/error.sh
+++ b/test/error.sh
@@ -240,3 +240,13 @@ def foo(opts: { a: int64, b: int64 })
   opts.a + opts.b
 end
 foo(100)'
+assert 'identifier `a` is bound more than once in the same pattern' '
+case { a: 100, b: 200, c: 300 }
+when { a, ...a }
+  puts(a)
+end'
+assert 'spread pattern can appear only once' '
+case { a: 100, b: 200, c: 300 }
+when { a, ...x, ...y }
+  puts(a)
+end'

--- a/test/error.sh
+++ b/test/error.sh
@@ -168,7 +168,6 @@ assert 'uncovered fields `a`, `b`' "
   else
     puts(2)
   end"
-# destructuring
 assert 'named field `value` is defined more than once' "
   struct T { value: int64 }
   case T { value: 123 }

--- a/test/error.sh
+++ b/test/error.sh
@@ -151,11 +151,28 @@ assert 'Semantic error: non-exhaustive pattern: `T { a: false, b: false }`' "
   when T { a: false, b: true }
     puts(3)
   end"
-# uncovered fields
-assert 'Semantic error: uncovered fields `value` in struct pattern `struct T { value: int64 }`' "
+# destructuring
+assert 'uncovered fields `value`' "
   struct T { value: int64 }
   case T { value: 123 }
   when T {}
+    puts(0)
+  else
+    puts(1)
+  end"
+assert 'uncovered fields `a`, `b`' "
+  struct T { a: int64, b: int64 }
+  case T { a: 1, b: 2 }
+  when T {}
+    puts(0)
+  else
+    puts(2)
+  end"
+# destructuring
+assert 'named field `value` is defined more than once' "
+  struct T { value: int64 }
+  case T { value: 123 }
+  when T { value: a, value: b }
     puts(0)
   else
     puts(1)

--- a/test/test.sh
+++ b/test/test.sh
@@ -357,6 +357,11 @@ D { baz, ... } = d
 puts(baz, foo)'
 # anonymous struct
 assert '{ a: 1 }' 'puts({a: 1})'
+assert '{ b: true, m: "hello" }' 'puts({m: "hello", b: true})'
+assert '{ t: { a: 123 }, z: 33 }' '
+t1 = { a: 123 }
+t2 = { t: t1, z: 33}
+puts(t2)'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -404,6 +404,12 @@ case { a: 100, b: 200, c: 300 }
 when { a, ...x }
   puts(a, x.c)
 end'
+assert '100 300' '
+struct T { a: int64, b: int64, c: int64 }
+case T { a: 100, b: 200, c: 300 }
+when T { a, ...x }
+  puts(a, x.c)
+end'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -374,6 +374,11 @@ def foo(n: int64, options: { repeat: boolean, count: int64 })
 end
 6.foo({ count: 0, repeat: false }).puts()
 3.foo({ count: 3, repeat: true }).puts()'
+assert '123' '
+def foo({ a, ... }: { a: int64 })
+  a
+end
+{ a: 123 }.foo().puts()'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -383,6 +383,17 @@ assert '{ a: 100, b: 200, c: 300 }' '
 t1 = { a: 100, b: 200 }
 t2 = { c: 300, ...t1 }
 puts(t2)'
+assert 'T { a: 100, b: 200, c: 400 }' '
+struct T { a: int64, b: int64, c: int64, }
+t1 = T { a: 100, b: 200, c: 300 }
+t2 = T { ...t1, c: 400 }
+puts(t2)'
+assert 'T { a: 0, b: 1, c: 400 }' '
+struct T { a: int64, b: int64, c: int64, }
+t1 = T { a: 100, b: 200, c: 300 }
+t2 = T { ...t1, c: 400 }
+t3 = T { ...t1, ...t2, a: 0, b: 1 }
+puts(t3)'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -355,6 +355,8 @@ D { bar: _, ... } = d
 D { foo, ... } = d
 D { baz, ... } = d
 puts(baz, foo)'
+# anonymous struct
+assert '{ a: 1 }' 'puts({a: 1})'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -362,6 +362,18 @@ assert '{ t: { a: 123 }, z: 33 }' '
 t1 = { a: 123 }
 t2 = { t: t1, z: 33}
 puts(t2)'
+assert '6
+9' '
+def foo(n: int64, options: { repeat: boolean, count: int64 })
+  case options.repeat
+  when true
+    options.count * n
+  else
+    n
+  end
+end
+6.foo({ count: 0, repeat: false }).puts()
+3.foo({ count: 3, repeat: true }).puts()'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -404,11 +404,11 @@ case { a: 100, b: 200, c: 300 }
 when { a, ...x }
   puts(a, x.c)
 end'
-assert '100 300' '
+assert '100 200 300' '
 struct T { a: int64, b: int64, c: int64 }
 case T { a: 100, b: 200, c: 300 }
 when T { a, ...x }
-  puts(a, x.c)
+  puts(a, x.b, x.c)
 end'
 # examples
 assert 13 "$(cat examples/foo.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -398,8 +398,12 @@ assert '100' '
 case { a: 100, b: 200 }
 when { a, ... }
   puts(a)
-end
-'
+end'
+assert '100 300' '
+case { a: 100, b: 200, c: 300 }
+when { a, ...x }
+  puts(a, x.c)
+end'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -415,6 +415,16 @@ struct T { a: int64, b: int64, c: int64 }
 t1 = T { a: 1, b: 2, c: 3 }
 { a, ...x } = t1
 puts(a, x.c)'
+assert 'T { a: 50, b: 10, c: 40 }' '
+struct T {
+  a: int64,
+  b: int64,
+  c: int64,
+}
+t1 = T { a: 1, b: 2, c: 3 }
+t2 = T { ...t1, a: 3, b: 10 } # { a: 3, b: 10, c: 3 }
+t3 = T { ...t1, ...t2, ...{ a: 50, c: 40 } }
+puts(t3)'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -410,6 +410,11 @@ case T { a: 100, b: 200, c: 300 }
 when T { a, ...x }
   puts(a, x.b, x.c)
 end'
+assert '1 3' '
+struct T { a: int64, b: int64, c: int64 }
+t1 = T { a: 1, b: 2, c: 3 }
+{ a, ...x } = t1
+puts(a, x.c)'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -379,6 +379,10 @@ def foo({ a, ... }: { a: int64 })
   a
 end
 { a: 123 }.foo().puts()'
+assert '{ a: 100, b: 200, c: 300 }' '
+t1 = { a: 100, b: 200 }
+t2 = { c: 300, ...t1 }
+puts(t2)'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -325,19 +325,12 @@ assert 'Year 2022' '
 struct D { foo: int64, bar: boolean, baz: string }
 d = D { bar: true, foo: 2022, baz: "Year" }
 D { bar: x, foo: y, baz: z} = d
-case D { bar: x, foo: y, baz: z}
-when D { bar: false }
+case D { bar: x, foo: y, baz: z }
+when D { bar: false, ... }
   puts(false)
-when D { foo: foo, baz }
+when D { foo: foo, baz, ... }
   puts(baz, foo)
 end'
-assert 'Year 2022' '
-struct D { foo: int64, bar: boolean, baz: string }
-d = D { bar: true, foo: 2022, baz: "Year" }
-D { bar: _ } = d
-D { foo } = d
-D { baz } = d
-puts(baz, foo)'
 assert 'Year 2022' '
 struct D { foo: int64, bar: boolean, baz: string }
 d = D { bar: true, foo: 2022, baz: "Year" }
@@ -346,15 +339,22 @@ assert '3' '
 struct D { foo: int64, bar: boolean, baz: string }
 d = D { bar: false, foo: 1000, baz: "Hello" }
 case d
-when D { bar: true }
+when D { bar: true, ... }
   puts(1)
-when D { foo: 999 }
+when D { foo: 999, ... }
   puts(2)
-when D { baz: "Hello" }
+when D { baz: "Hello", ... }
   puts(3)
 else
   puts(4)
 end'
+assert 'Year 2022' '
+struct D { foo: int64, bar: boolean, baz: string }
+d = D { bar: true, foo: 2022, baz: "Year" }
+D { bar: _, ... } = d
+D { foo, ... } = d
+D { baz, ... } = d
+puts(baz, foo)'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"

--- a/test/test.sh
+++ b/test/test.sh
@@ -394,6 +394,12 @@ t1 = T { a: 100, b: 200, c: 300 }
 t2 = T { ...t1, c: 400 }
 t3 = T { ...t1, ...t2, a: 0, b: 1 }
 puts(t3)'
+assert '100' '
+case { a: 100, b: 200 }
+when { a, ... }
+  puts(a)
+end
+'
 # examples
 assert 13 "$(cat examples/foo.paty)"
 assert 55 "$(cat examples/fib.paty)"


### PR DESCRIPTION
`{...}` is syntax for constructing an anonymous structure that can be freely defined at any time.

```ruby
def foo(options: {repeat: boolean, count: int64})
  ...
end
```

Unlike named struct, this kind of value is matched by structual, so if two values have the same fields and types, they are treated as the same type.

```ruby
foo({ repeat: true, count: 40 }) # ok
foo({ count: 30, repeat: false }) # ok

# The following cases are consideed as compile errors for now.
# We may allow them in the future.

# Named and anonymous structs are not compatible.
struct T {repeat: boolean, count: int64}
foo(T { count: 30, repeat: false }) # Error

# Compile error because the required fields are defined in the anonymous structure, but extra fields are included.
foo({ repeat: false, count: 10, message: "dummy" }) # Error
```

You can also use anonymous struct as pattern:

```ruby
# A newly created anonymous struct `{ a: int64, b: int64, c: int64 }`
t = { a: 1, b: 2, c: 3 }
case t
when { a, b: value, c }
  ...
end
```

Also, in the structure pattern, fields cannot be omitted. If you want to omit a field, specify it explicitly with the newly introduced spread pattern.

```ruby
case t
when T { a, b: value, ... } # Omits fields except for `a` and `b`
  ...
end
```

You can also specify variable names in the spread pattern, and capture the omitted fields as an anonymous structure.

```ruby
case t
when T { a, b: value, ...x } # x is an anonymous struct value. You can refer `c` as `x.c`
  ...
end
```

The spread operator has also been introduced, which allows you to use a different structure to initialize a structure.

```ruby
struct T {
  a: int64,
  b: int64,
  c: int64,
}
t1 = T { a: 1, b: 2, c: 3 }
t2 = T { ...t1, a: 3, b: 10 } # { a: 3, b: 10, c: 3 }
t3 = T { ...t1, ...t2, ...{ a: 50, c: 40 } } # T { a: 50, b: 10, c: 40 }
```